### PR TITLE
fix for #9 - support for #load to load dependent scripts (clean)

### DIFF
--- a/src/Scriptcs/FilePreProcessor.cs
+++ b/src/Scriptcs/FilePreProcessor.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel.Composition;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Scriptcs
+{
+    public class FilePreProcessor : IFilePreProcessor
+    {
+        private const string LoadString = "#load ";
+        private const string UsingString = "using ";
+
+        private readonly IFileSystem _fileSystem;
+
+        [ImportingConstructor]
+        public FilePreProcessor(IFileSystem fileSystem)
+        {
+            _fileSystem = fileSystem;
+        }
+
+        public string ProcessFile(string path)
+        {
+            var entryFile = _fileSystem.ReadFileLines(path);
+            var parsed = ParseFile(entryFile);
+
+            var result = string.Join(_fileSystem.NewLine, parsed.Item1);
+            result += _fileSystem.NewLine + parsed.Item2;
+
+            return result;
+        }
+
+        private Tuple<List<string>, string> ParseFile(IEnumerable<string> file)
+        {
+            var usings = new List<string>();
+
+            var fileList = file.ToList();
+            for (var i = 0; i < fileList.Count; i++)
+            {
+                var line = fileList[i];
+                if (IsUsingLine(line))
+                {
+                    usings.Add(line);
+                }
+
+                if (IsLoadLine(line))
+                {
+                    var filepath = line.Trim(' ').Replace(LoadString, "").Replace("\"", "").Replace(";","");
+                    var filecontent = _fileSystem.IsPathRooted(filepath)
+                                              ? _fileSystem.ReadFileLines(filepath)
+                                              : _fileSystem.ReadFileLines(_fileSystem.CurrentDirectory + @"\" + filepath);
+
+                    if (filecontent != null)
+                    {
+                        var parsed = ParseFile(filecontent);
+                        fileList[i] = parsed.Item2;
+                        usings.AddRange(parsed.Item1);
+                    }
+                }
+            }
+
+            var result = string.Join(_fileSystem.NewLine, fileList.Where(line => !IsUsingLine(line)));
+            var tuple = new Tuple<List<string>, string>(usings.Distinct().ToList(), result);
+
+            return tuple;
+        }        
+
+        private static bool IsUsingLine(string line)
+        {
+            return line.TrimStart(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";");
+        }
+
+        private static bool IsLoadLine(string line)
+        {
+            return line.TrimStart(' ').StartsWith(LoadString);
+        }
+    }
+}

--- a/src/Scriptcs/FileSystem.cs
+++ b/src/Scriptcs/FileSystem.cs
@@ -34,9 +34,24 @@ namespace Scriptcs
             return File.ReadAllText(path);
         }
 
+        public string[] ReadFileLines(string path)
+        {
+            return File.ReadAllLines(path);
+        }
+
+        public bool IsPathRooted(string path)
+        {
+            return Path.IsPathRooted(path);
+        }
+
         public string CurrentDirectory
         {
             get { return Environment.CurrentDirectory; }
+        }
+
+        public string NewLine
+        {
+            get { return Environment.NewLine; }
         }
 
         public DateTime GetLastWriteTime(string file)

--- a/src/Scriptcs/IFilePreProcessor.cs
+++ b/src/Scriptcs/IFilePreProcessor.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.Composition;
+
+namespace Scriptcs
+{
+    [InheritedExport]
+    public interface IFilePreProcessor
+    {
+        string ProcessFile(string path);
+    }
+}

--- a/src/Scriptcs/IFileSystem.cs
+++ b/src/Scriptcs/IFileSystem.cs
@@ -15,7 +15,11 @@ namespace Scriptcs
         bool DirectoryExists(string path);
         void CreateDirectory(string path);
         string ReadFile(string path);
-        string CurrentDirectory { get; }
+        string[] ReadFileLines(string path);
         DateTime GetLastWriteTime(string file);
+        bool IsPathRooted(string path);
+
+        string CurrentDirectory { get; }
+        string NewLine { get; }
     }
 }

--- a/src/Scriptcs/ScriptExecutor.cs
+++ b/src/Scriptcs/ScriptExecutor.cs
@@ -13,11 +13,13 @@ namespace Scriptcs
     public class ScriptExecutor : IScriptExecutor
     {
         private readonly IFileSystem _fileSystem;
+        private readonly IFilePreProcessor _filePreProcessor;
 
         [ImportingConstructor]
-        public ScriptExecutor(IFileSystem fileSystem)
+        public ScriptExecutor(IFileSystem fileSystem, IFilePreProcessor filePreProcessor)
         {
             _fileSystem = fileSystem;
+            _filePreProcessor = filePreProcessor;
         }
 
         public void Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptcsRecipe> recipes)
@@ -41,9 +43,10 @@ namespace Scriptcs
     
                 engine.AddReference(destFile);
             }
- 
+
             var session = engine.CreateSession();
-            var csx = _fileSystem.ReadFile(_fileSystem.CurrentDirectory + @"\" + script);
+            var path = _fileSystem.CurrentDirectory + @"\" + script;
+            var csx = _filePreProcessor.ProcessFile(path);
             session.Execute(csx);
             
         }

--- a/src/Scriptcs/Scriptcs.csproj
+++ b/src/Scriptcs/Scriptcs.csproj
@@ -68,7 +68,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FilePreProcessor.cs" />
     <Compile Include="FileSystem.cs" />
+    <Compile Include="IFilePreProcessor.cs" />
     <Compile Include="IFileSystem.cs" />
     <Compile Include="IPackageAssemblyResolver.cs" />
     <Compile Include="IRecipeManager.cs" />

--- a/test/Scriptcs.Tests/FileProcessorTests.cs
+++ b/test/Scriptcs.Tests/FileProcessorTests.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Moq;
+using Xunit;
+
+namespace Scriptcs.Tests
+{
+    public class FileProcessorTests
+    {
+        private List<string> file1 = new List<string>
+            {
+                "using System;",
+                @"Console.WriteLine(""Hello Script 1"");",
+                @"Console.WriteLine(""Loading Script 2"");",
+                @"#load ""script2.csx""",
+                @"Console.WriteLine(""Loaded Script 2"");",
+                @"Console.WriteLine(""Loading Script 4"");",
+                @"#load ""script4.csx"";",
+                @"Console.WriteLine(""Loaded Script 4"");",
+                @"Console.WriteLine(""Goodbye Script 1"");"
+            };
+
+        private List<string> file2 = new List<string>
+            {
+                "using System;",
+                @"Console.WriteLine(""Hello Script 2"");",
+                @"Console.WriteLine(""Loading Script 3"");",
+                @"#load ""script3.csx""",
+                @"Console.WriteLine(""Loaded Script 3"");",
+                @"Console.WriteLine(""Goodbye Script 2"");"
+            };
+
+        private List<string> file3 = new List<string>
+            {
+                "using System;",
+                "using System.Collections.Generic;",
+                @"Console.WriteLine(""Hello Script 3"");",
+                @"Console.WriteLine(""Goodbye Script 3"");"
+            };
+
+        private List<string> file4 = new List<string>
+            {
+                "using System;",
+                "using System.Core;",
+                @"Console.WriteLine(""Hello Script 4"");",
+                @"Console.WriteLine(""Goodbye Script 4"");"
+            };
+
+        private readonly Mock<IFileSystem> _fileSystem;
+
+        public FileProcessorTests()
+        {
+            _fileSystem = new Mock<IFileSystem>();
+            _fileSystem.SetupGet(x => x.NewLine).Returns(Environment.NewLine);
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\script1.csx")))
+                       .Returns(file1.ToArray());
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\script2.csx")))
+                       .Returns(file2.ToArray());
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\script3.csx")))
+                       .Returns(file3.ToArray());
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\script4.csx")))
+                        .Returns(file4.ToArray());
+        }
+
+        [Fact]
+        public void MultipleUsingStatementsShouldProduceDistinctOutput()
+        {
+            var processor = new FilePreProcessor(_fileSystem.Object);
+            var output = processor.ProcessFile("\\script1.csx");
+
+            var splitOutput = output.Split(new[] {Environment.NewLine}, StringSplitOptions.None);
+
+            _fileSystem.Verify(x => x.ReadFileLines(It.Is<string>(i => i.StartsWith("\\script"))),Times.Exactly(4));
+            Assert.Equal(3, splitOutput.Count(x => x.TrimStart(' ').StartsWith("using ")));
+        }
+
+        [Fact]
+        public void UsingStateMentsShoulAllBeAtTheTop()
+        {
+            var processor = new FilePreProcessor(_fileSystem.Object);
+            var output = processor.ProcessFile("\\script1.csx");
+
+            var splitOutput = output.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var lastUsing = splitOutput.ToList().FindLastIndex(x => x.TrimStart(' ').StartsWith("using "));
+            var firsNotUsing = splitOutput.ToList().FindIndex(x => !x.TrimStart(' ').StartsWith("using "));
+
+            Assert.True(lastUsing < firsNotUsing);
+        }
+
+        [Fact]
+        public void ThreeLoadedFilesShoulAllBeCalledOnce()
+        {
+            var processor = new FilePreProcessor(_fileSystem.Object);
+            var output = processor.ProcessFile("\\script1.csx");
+
+            _fileSystem.Verify(x => x.ReadFileLines(It.Is<string>(i => i == "\\script1.csx")), Times.Once());
+            _fileSystem.Verify(x => x.ReadFileLines(It.Is<string>(i => i == "\\script2.csx")), Times.Once());
+            _fileSystem.Verify(x => x.ReadFileLines(It.Is<string>(i => i == "\\script3.csx")), Times.Once());
+            _fileSystem.Verify(x => x.ReadFileLines(It.Is<string>(i => i == "\\script4.csx")), Times.Once());
+        }
+
+        [Fact]
+        public void LoadBeforeUsingShouldBeAllowed()
+        {
+            var file = new List<string>
+                {
+                    @"#load ""script4.csx""",
+                    "",
+                    "using System;",
+                    @"Console.WriteLine(""abc"");"
+                };
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\file.csx"))).Returns(file.ToArray());
+
+            var processor = new FilePreProcessor(_fileSystem.Object);
+            var output = processor.ProcessFile("\\file.csx");
+
+            var splitOutput = output.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var lastUsing = splitOutput.ToList().FindLastIndex(x => x.TrimStart(' ').StartsWith("using "));
+            var firsNotUsing = splitOutput.ToList().FindIndex(x => !x.TrimStart(' ').StartsWith("using "));
+
+            Assert.Equal(2, splitOutput.Count(x => x.TrimStart(' ').StartsWith("using ")));
+            Assert.True(lastUsing < firsNotUsing);            
+        }
+
+        [Fact]
+        public void UsingInCodeDoesNotCountAsUsingImport()
+        {
+            var file = new List<string>
+                {
+                    @"#load ""script4.csx""",
+                    "",
+                    "using System;",
+                    "using System.IO;",
+                    "Console.WriteLine();",
+                    @"using (var stream = new MemoryStream) {",
+                    @"//do stuff",
+                    @"}"
+                };
+            _fileSystem.Setup(x => x.ReadFileLines(It.Is<string>(f => f == "\\file.csx"))).Returns(file.ToArray());
+
+            var processor = new FilePreProcessor(_fileSystem.Object);
+            var output = processor.ProcessFile("\\file.csx");
+
+            var splitOutput = output.Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            var firstNonImportUsing = splitOutput.ToList().FindIndex(x => x.TrimStart(' ').StartsWith("using ") && !x.Contains(";"));
+            var firstCodeLine = splitOutput.ToList().FindIndex(x => x.Contains("Console"));
+
+            Assert.True(firstNonImportUsing > firstCodeLine);
+        }
+    }
+}

--- a/test/Scriptcs.Tests/Scriptcs.Tests.csproj
+++ b/test/Scriptcs.Tests/Scriptcs.Tests.csproj
@@ -53,6 +53,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="FileProcessorTests.cs" />
     <Compile Include="PackageAssemblyResolverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
Example use:

```
     //script1
            #load "script2.csx"
            using System;
            using System.Collections;

            Console.WriteLine("Hello Script 1");

     //script2
            using System;
            using System.Core;

            Console.WriteLine("Hello Script 2");
```

Will produce:

```
            using System;
            using System.Core;
            using System.Collections;

            Console.WriteLine("Hello Script 2");
            Console.WriteLine("Hello Script 1");
```

Also supports:
- being called inline (not just on top of the file).
- absolute script paths (although am not sure about that)
