### PR TITLE
Run scripts even when Packages folder doesn't exist

### DIFF
--- a/src/Scriptcs/PackageAssemblyResolver.cs
+++ b/src/Scriptcs/PackageAssemblyResolver.cs
@@ -21,6 +21,10 @@ namespace Scriptcs
         public IEnumerable<string> GetAssemblyNames()
         {
             var packageDir = _fileSystem.CurrentDirectory + @"\" + "packages";
+
+            if (!File.Exists(packageDir))
+                return Enumerable.Empty<string>();
+
             var folders = new List<string>();
             var files = new List<string>();
             foreach (var file in Directory.EnumerateFiles(packageDir, @"*.dll", SearchOption.AllDirectories))


### PR DESCRIPTION
I tried running a simple Hello, World script and got an exception because there was no packages folder in the current directory. I don't think you need this folder if you're not using any nuget packages, so I just return an empty list of paths.
