### PR TITLE
Fixed bug where current directory was beeing prepended to script path

### DIFF
--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -1,4 +1,5 @@
-﻿using Roslyn.Scripting.CSharp;
+﻿using System;
+using Roslyn.Scripting.CSharp;
 using ScriptCs.Contracts;
 using System.Collections.Generic;
 using System.ComponentModel.Composition;
@@ -23,7 +24,7 @@ namespace ScriptCs
             var engine = new ScriptEngine();
             engine.AddReference("System");
             engine.AddReference("System.Core");
-            var bin = _fileSystem.CurrentDirectory + @"\bin";
+            var bin = Path.Combine(_fileSystem.CurrentDirectory, "bin");
             engine.BaseDirectory = bin;
 
             if (!_fileSystem.DirectoryExists(bin))
@@ -31,7 +32,7 @@ namespace ScriptCs
 
             foreach (var file in paths)
             {
-                var destFile = bin + @"\" + Path.GetFileName(file);
+                var destFile = Path.Combine(bin, Path.GetFileName(file));
                 var sourceFileLastWriteTime = _fileSystem.GetLastWriteTime(file);
                 var destFileLastWriteTime = _fileSystem.GetLastWriteTime(destFile);
                 if (sourceFileLastWriteTime != destFileLastWriteTime)
@@ -41,7 +42,7 @@ namespace ScriptCs
             }
 
             var session = engine.CreateSession();
-            var path = _fileSystem.CurrentDirectory + @"\" + script;
+            var path = Path.IsPathRooted(script) ? script : Path.Combine(_fileSystem.CurrentDirectory, script);
             var csx = _filePreProcessor.ProcessFile(path);
             session.Execute(csx);
         }

--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -16,7 +16,7 @@ namespace ScriptCs
             }
 
             var script = args[0];
-
+            
             var recipes = new List<string>();
             if (args.Length > 1)
             {

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -50,8 +50,13 @@
     <Compile Include="FileProcessorTests.cs" />
     <Compile Include="PackageAssemblyResolverTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ScriptExecutorTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\src\ScriptCs.Contracts\ScriptCs.Contracts.csproj">
+      <Project>{6049e205-8b5f-4080-b023-70600e51fd64}</Project>
+      <Name>ScriptCs.Contracts</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\Scriptcs.Core\Scriptcs.Core.csproj">
       <Project>{e590e710-e159-48e6-a3e6-1a83d3fe732c}</Project>
       <Name>Scriptcs.Core</Name>

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using Moq;
+using ScriptCs.Contracts;
+using Xunit;
+
+namespace ScriptCs.Tests
+{
+    public class ScriptExecutorTests
+    {
+        private readonly Mock<IFileSystem> _fileSystem;
+        private readonly Mock<IFilePreProcessor> _preProcessor;
+
+        public ScriptExecutorTests()
+        {
+            _fileSystem = new Mock<IFileSystem>();
+            _fileSystem.Setup(f => f.CurrentDirectory).Returns(@"c:\my_script");
+
+            _preProcessor = new Mock<IFilePreProcessor>();
+            _preProcessor.Setup(p => p.ProcessFile(It.IsAny<string>())).Returns("var a = 0;");
+        }
+
+        [Fact]
+        public void ConstructsAbsolutePathBeforePreProcessingFile()
+        {            
+            var executor = new ScriptExecutor(_fileSystem.Object, _preProcessor.Object);
+            executor.Execute("script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptCsRecipe>());
+            _preProcessor.Verify(p => p.ProcessFile(@"c:\my_script\script.csx"));
+        }
+
+        [Fact]
+        public void DoNotChangePathIfAbsolute()
+        {
+            var executor = new ScriptExecutor(_fileSystem.Object, _preProcessor.Object);
+            executor.Execute(@"c:\my_script\script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptCsRecipe>());
+            _preProcessor.Verify(p => p.ProcessFile(@"c:\my_script\script.csx"));
+        }
+    }
+}


### PR DESCRIPTION
The ScriptExecutor pre-pended current directory to script path even if script path is an absolute path. Now the current directory is only pre-pended to relative paths.
