### PR TITLE
Throws if "packages" directory does not exist

### DIFF
--- a/src/Scriptcs/PackageAssemblyResolver.cs
+++ b/src/Scriptcs/PackageAssemblyResolver.cs
@@ -21,6 +21,9 @@ namespace Scriptcs
         public IEnumerable<string> GetAssemblyNames()
         {
             var packageDir = _fileSystem.CurrentDirectory + @"\" + "packages";
+            if (!Directory.Exists(packageDir))
+                return Enumerable.Empty<string>();
+						
             var folders = new List<string>();
             var files = new List<string>();
             foreach (var file in Directory.EnumerateFiles(packageDir, @"*.dll", SearchOption.AllDirectories))


### PR DESCRIPTION
PackageAssemblyResolver.GetAssemblyNames assumes that the local "packages" folder exists. For scripts that only require framework assys packages are unnecessary.

Simply added an "if(!Directory.Exsits..."
