### PR TITLE
Script execution result is returned as the ScriptCs.exe exit code

### DIFF
--- a/src/ScriptCs.Core/IScriptEngine.cs
+++ b/src/ScriptCs.Core/IScriptEngine.cs
@@ -5,6 +5,6 @@ namespace ScriptCs
 	public interface IScriptEngine
 	{
 		string BaseDirectory { get; set; }
-		void Execute(string code, IEnumerable<string> references, ScriptPackSession scriptPackSession);
+		object Execute(string code, IEnumerable<string> references, ScriptPackSession scriptPackSession);
 	}
 }

--- a/src/ScriptCs.Core/IScriptExecutor.cs
+++ b/src/ScriptCs.Core/IScriptExecutor.cs
@@ -5,6 +5,6 @@ namespace ScriptCs
 {
     public interface IScriptExecutor
     {
-        void Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> recipes);
+        object Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> recipes);
     }
 }

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -18,7 +18,7 @@ namespace ScriptCs
             _scriptEngine = scriptEngine;
         }
 
-        public void Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> scriptPacks)
+        public object Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> scriptPacks)
         {
             var bin = Path.Combine(_fileSystem.GetWorkingDirectory(script), "bin");
             var files = PrepareBinFolder(paths, bin);
@@ -36,12 +36,14 @@ namespace ScriptCs
             var path = Path.IsPathRooted(script) ? script : Path.Combine(_fileSystem.CurrentDirectory, script);
             var code = _filePreProcessor.ProcessFile(path);
             
-            _scriptEngine.Execute(
-                code: code,
-                references: references,
-                scriptPackSession: scriptPackSession);
+            var result = _scriptEngine.Execute(
+                            code: code,
+                            references: references,
+                            scriptPackSession: scriptPackSession);
 
             scriptPackSession.TerminatePacks();
+
+            return result;
         }
 
         private IEnumerable<string> PrepareBinFolder(IEnumerable<string> paths, string bin)

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptDebuggerEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptDebuggerEngine.cs
@@ -17,7 +17,7 @@ namespace ScriptCs.Engine.Roslyn
         {
         }
 
-        protected override void Execute(string code, Session session)
+        protected override object Execute(string code, Session session)
         {
             var submission = session.CompileSubmission<object>(code);
             var exeBytes = new byte[0];
@@ -50,7 +50,7 @@ namespace ScriptCs.Engine.Roslyn
 
                 try
                 {
-                    method.Invoke(null, new[] { session });
+                    return method.Invoke(null, new[] { session });
                 }
                 catch (Exception e)
                 {
@@ -63,6 +63,8 @@ namespace ScriptCs.Engine.Roslyn
                     throw new ScriptExecutionException(message);
                 }
             }
+
+            return null;
         }
     }
 }

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -23,7 +23,7 @@ namespace ScriptCs.Engine.Roslyn
             set {  _scriptEngine.BaseDirectory = value; }
         }
 
-        public void Execute(string code, IEnumerable<string> references, ScriptPackSession scriptPackSession)
+        public object Execute(string code, IEnumerable<string> references, ScriptPackSession scriptPackSession)
         {
             var contexts = scriptPackSession.ScriptPacks.Select(x => x.GetContext());
             var host = _scriptHostFactory.CreateScriptHost(contexts);
@@ -36,12 +36,12 @@ namespace ScriptCs.Engine.Roslyn
             foreach (var @namespace in scriptPackSession.Namespaces.Distinct())
                 session.ImportNamespace(@namespace);
 
-            Execute(code, session);
+            return Execute(code, session);
         }
 
-        protected virtual void Execute(string code, Session session)
+        protected virtual object Execute(string code, Session session)
         {
-            session.Execute(code);
+            return session.Execute(code);
         }
     }
 }

--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -33,8 +33,8 @@ namespace ScriptCs
                     Console.WriteLine("Found assembly reference: " + path);
                 }
 
-                scriptServiceRoot.Executor.Execute(script, paths, scriptServiceRoot.ScriptPackResolver.GetPacks());
-                return 0;
+                var result = scriptServiceRoot.Executor.Execute(script, paths, scriptServiceRoot.ScriptPackResolver.GetPacks());
+                return result is int ? (int)result : 0;
             }
             catch (Exception ex)
             {

--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
@@ -10,6 +10,7 @@ using Xunit;
 namespace ScriptCs.Tests
 {
     using Roslyn.Scripting.CSharp;
+    using Xunit.Extensions;
 
     public class RoslynScriptEngineTests
     {
@@ -48,6 +49,18 @@ namespace ScriptCs.Tests
                 scriptHostFactory.Verify(f => f.CreateScriptHost(It.IsAny<IEnumerable<IScriptPackContext>>()));
             }
 
+            [Theory]
+            [InlineData("1 + 1", 2)]
+            [InlineData("int a; a = 1;", 1)]
+            [InlineData("int a = 1;", null)]
+            [InlineData("var b = \"test\"; b", "test")]
+            [InlineData("System.Console.WriteLine()", null)]
+            public void ShouldReturnValueOfLastExpressionOrNullForVoid(string code, object expectedResult)
+            {
+                var engine = CreateScriptEngine();
+                var result = engine.Execute(code, Enumerable.Empty<string>(), new ScriptPackSession(Enumerable.Empty<IScriptPack>()));
+                result.ShouldEqual(expectedResult, "Script: " + code);
+            }
         }
     }
 }

--- a/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
+++ b/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
@@ -31,6 +31,9 @@
     <Reference Include="xunit">
       <HintPath>..\..\packages\xunit.1.9.1\lib\net20\xunit.dll</HintPath>
     </Reference>
+    <Reference Include="xunit.extensions">
+      <HintPath>..\..\packages\xunit.extensions.1.9.1\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\common\CommonAssemblyInfo.cs">

--- a/test/ScriptCs.Engine.Roslyn.Tests/packages.config
+++ b/test/ScriptCs.Engine.Roslyn.Tests/packages.config
@@ -5,4 +5,5 @@
   <package id="Roslyn.Compilers.CSharp" version="1.2.20906.2" targetFramework="net45" />
   <package id="Should" version="1.1.12.0" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
+  <package id="xunit.extensions" version="1.9.1" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR propagates script's return value to scriptcs.exe's exit code. It allows the script to set its execution result.

The algorithm is the following:
- If a script returns a value of type int, then this value is used as an exit code.
- If a script returns null or value of type other than int, then exit code is 0.
- If a script throws an exception, then exit code is -1.
