### PR TITLE
Support for ScriptCS files that only contain a #load

### DIFF
--- a/src/ScriptCs.Core/FilePreProcessor.cs
+++ b/src/ScriptCs.Core/FilePreProcessor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace ScriptCs
@@ -87,7 +88,7 @@ namespace ScriptCs
                 } 
                 else if (IsLoadLine(line))
                 {
-                    if (i < firstCode && !loads.Contains(line))
+                    if ((i < firstCode || firstCode < 0) && !loads.Contains(line))
                     {
                         var filepath = line.Trim(' ').Replace(LoadString, string.Empty).Replace("\"", string.Empty).Replace(";", string.Empty);
                         var filecontent = _fileSystem.IsPathRooted(filepath)


### PR DESCRIPTION
If a file only contains #load lines, the `firstCode` variable will be -1, so the file was never loaded. Now this scenario will be supported.

For example, take this file:

`Loader.csx`:

```
#load "config.csx"
#load "program.csx"
```

This file has no "first code" line, so the load lines were being skipped, resulting in nothing happening. 
