### PR TITLE
ExecuteScriptCommand now creates bin folder if it's missing.

### DIFF
--- a/src/ScriptCs/Command/ExecuteScriptCommand.cs
+++ b/src/ScriptCs/Command/ExecuteScriptCommand.cs
@@ -46,6 +46,9 @@ namespace ScriptCs.Command
         {
             var binFolder = Path.Combine(workingDirectory, "bin");
 
+            if (!_fileSystem.DirectoryExists(binFolder))
+                _fileSystem.CreateDirectory(binFolder);
+
             var assemblyPaths = _fileSystem.EnumerateFiles(binFolder, "*.dll").ToList();
             foreach (var path in assemblyPaths.Select(Path.GetFileName))
             {

--- a/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.IO;
+
 using Moq;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
@@ -34,6 +36,33 @@ namespace ScriptCs.Tests
                 result.Execute();
 
                 executor.Verify(i => i.Execute(It.Is<string>(x => x == "test.csx"), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
+            }
+
+            [Fact]
+            public void ShouldCreateMissingBinFolder()
+            {
+                const string WorkingDirectory = @"C:\";
+
+                var binFolder = Path.Combine(WorkingDirectory, "bin");
+
+                var args = new ScriptCsArgs { ScriptName = "test.csx" };
+
+                var fs = new Mock<IFileSystem>();
+                fs.Setup(x => x.GetWorkingDirectory(It.IsAny<string>())).Returns(WorkingDirectory);
+                fs.Setup(x => x.DirectoryExists(binFolder)).Returns(false);
+
+                var resolver = new Mock<IPackageAssemblyResolver>();
+                var executor = new Mock<IScriptExecutor>();
+                var scriptpackResolver = new Mock<IScriptPackResolver>();
+                var packageInstaller = new Mock<IPackageInstaller>();
+                var root = new ScriptServiceRoot(fs.Object, resolver.Object, executor.Object, scriptpackResolver.Object, packageInstaller.Object);
+
+                var factory = new CommandFactory(root);
+                var result = factory.CreateCommand(args);
+
+                result.Execute();
+
+                fs.Verify(x => x.CreateDirectory(binFolder), Times.Once());
             }
         }
     }


### PR DESCRIPTION
Fixes #151 :smile: 
