### PR TITLE
Pick the newest supported framework for the packages to restore

### DIFF
--- a/src/ScriptCs.Core/Package/PackageContainer.cs
+++ b/src/ScriptCs.Core/Package/PackageContainer.cs
@@ -1,12 +1,16 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
+
 using NuGet;
 
 namespace ScriptCs.Package
 {
     public class PackageContainer : IPackageContainer
     {
+        private const string DotNetFramework = ".NETFramework";
+
         private readonly IFileSystem _fileSystem;
 
         public PackageContainer(IFileSystem fileSystem)
@@ -16,33 +20,38 @@ namespace ScriptCs.Package
 
         public IEnumerable<string> CreatePackageFile()
         {
-            var packageReferenceFile = new PackageReferenceFile(Path.Combine(_fileSystem.CurrentDirectory, Constants.PackagesFile));
-            var repository = new LocalPackageRepository(Path.Combine(_fileSystem.CurrentDirectory, Constants.PackagesFolder));
-            var arbitraryPackages = repository.GetPackages();
-            var result = new List<string>();
+            var packagesFile = Path.Combine(_fileSystem.CurrentDirectory, Constants.PackagesFile);
+            var packageReferenceFile = new PackageReferenceFile(packagesFile);
 
-            foreach (var package in arbitraryPackages.GroupBy(i => i.Id))
+            var packagesFolder = Path.Combine(_fileSystem.CurrentDirectory, Constants.PackagesFolder);
+            var repository = new LocalPackageRepository(packagesFolder);
+
+            var newestPackages = repository.GetPackages().GroupBy(p => p.Id)
+                .Select(g => g.OrderByDescending(p => p.Version).FirstOrDefault());
+
+            foreach (var package in newestPackages)
             {
-                var p = package.OrderByDescending(i => i.Version).FirstOrDefault();
-                packageReferenceFile.AddEntry(p.Id, p.Version, VersionUtility.ParseFrameworkName("net45"));
-                result.Add(string.Format("{0}, Version {1}, .NET 4.5", p.Id, p.Version));
-            }
+                var newestFramework = GetNewestSupportedFramework(package);
+                packageReferenceFile.AddEntry(package.Id, package.Version, newestFramework);
 
-            return result;
+                if (newestFramework == null)
+                {
+                    yield return string.Format("{0}, Version {1}", package.Id, package.Version);
+                }
+                else
+                {
+                    yield return string.Format("{0}, Version {1}, .NET {2}", package.Id, package.Version, newestFramework.Version);
+                }
+            }
         }
 
         public IPackageObject FindPackage(string path, IPackageReference packageRef)
         {
             var repository = new LocalPackageRepository(path);
-            IPackage package;
-            if (packageRef.Version != null)
-            {
-                package = repository.FindPackage(packageRef.PackageId, new SemanticVersion(packageRef.Version, packageRef.SpecialVersion), true, true);
-            }
-            else
-            {
-                package = repository.FindPackage(packageRef.PackageId);
-            }
+
+            var package = packageRef.Version != null 
+                ? repository.FindPackage(packageRef.PackageId, new SemanticVersion(packageRef.Version, packageRef.SpecialVersion), true, true) 
+                : repository.FindPackage(packageRef.PackageId);
 
             return package == null ? null : new PackageObject(package, packageRef.FrameworkName);
         }
@@ -50,26 +59,50 @@ namespace ScriptCs.Package
         public IEnumerable<IPackageReference> FindReferences(string path)
         {
             var packageReferenceFile = new PackageReferenceFile(path);
-            var references = packageReferenceFile.GetPackageReferences();
 
-            if (!references.Any())
+            var references = packageReferenceFile.GetPackageReferences().ToList();
+            if (references.Any())
             {
-                var packagesFolder = Path.Combine(_fileSystem.GetWorkingDirectory(path), Constants.PackagesFolder);
-                if (_fileSystem.DirectoryExists(packagesFolder))
+                foreach (var packageReference in references)
                 {
-                    var repository = new LocalPackageRepository(packagesFolder);
-                    var arbitraryPackages = repository.GetPackages().Where(i => i.GetSupportedFrameworks().Any(x => x.FullName == VersionUtility.ParseFrameworkName("net40").FullName)).ToList();
-                    if (arbitraryPackages.Any())
-                    {
-                        return arbitraryPackages.Select(i => new PackageReference(i.Id, VersionUtility.ParseFrameworkName("net40"), i.Version.Version) { SpecialVersion = i.Version.SpecialVersion });
-                    }
+                    yield return new PackageReference(
+                            packageReference.Id,
+                            packageReference.TargetFramework,
+                            packageReference.Version.Version,
+                            packageReference.Version.SpecialVersion);
                 }
 
-                return Enumerable.Empty<IPackageReference>();
+                yield break;
             }
 
-            var packages = references.Select(i => new PackageReference(i.Id, i.TargetFramework, i.Version.Version) { SpecialVersion = i.Version.SpecialVersion });
-            return packages;
+            // No packages.config, check packages folder
+            var packagesFolder = Path.Combine(_fileSystem.GetWorkingDirectory(path), Constants.PackagesFolder);
+            if (!_fileSystem.DirectoryExists(packagesFolder)) yield break;
+
+            var repository = new LocalPackageRepository(packagesFolder);
+
+            var arbitraryPackages = repository.GetPackages();
+            if (!arbitraryPackages.Any()) yield break;
+
+            foreach (var arbitraryPackage in arbitraryPackages)
+            {
+                var newestFramework = GetNewestSupportedFramework(arbitraryPackage) 
+                    ?? VersionUtility.EmptyFramework;
+
+                yield return new PackageReference(
+                        arbitraryPackage.Id,
+                        newestFramework,
+                        arbitraryPackage.Version.Version,
+                        arbitraryPackage.Version.SpecialVersion);
+            }
+        }
+
+        private static FrameworkName GetNewestSupportedFramework(IPackage packageMetadata)
+        {
+            return packageMetadata.GetSupportedFrameworks()
+                .Where(x => x.Identifier == DotNetFramework)
+                .OrderByDescending(x => x.Version)
+                .FirstOrDefault();
         }
     }
 }

--- a/src/ScriptCs.Core/Package/PackageReference.cs
+++ b/src/ScriptCs.Core/Package/PackageReference.cs
@@ -6,15 +6,22 @@ namespace ScriptCs.Package
     public class PackageReference : IPackageReference
     {
         public PackageReference(string packageId, FrameworkName frameworkName, Version version)
+            : this(packageId, frameworkName, version, null) { }
+
+        public PackageReference(string packageId, FrameworkName frameworkName, Version version, string specialVersion)
         {
             FrameworkName = frameworkName;
             PackageId = packageId;
             Version = version;
+            SpecialVersion = specialVersion;
         }
 
         public string PackageId { get; private set; }
+
         public FrameworkName FrameworkName { get; private set; }
+
         public Version Version { get; set; }
+
         public string SpecialVersion { get; set; }
     }
 }


### PR DESCRIPTION
At least it picks an existing framework version :smile:  
This could be a potential fix for #185, but we should test this thoroughly first...

Do you guys see any problems with picking the newest supported framework for the packages, maybe with PCLs?
