### PR TITLE
Added "scriptcs -install" to Readme.md Quick Start Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ Write C# apps with a text editor, nuget and the power of Rosyln!
 ## Quick start
 * Open a cmd prompt as admin
 * Create a directory "c:\scriptcs_hello" and change to it.
-* run "nuget install Microsoft.AspNet.WebApi.SelfHost -o Packages"
-* run "scriptcs -install"
+* run "scriptcs -install Microsoft.AspNet.WebApi.SelfHost"
 * create a server.csx with your favorite editor. Paste the text below into the file and save.
 
 ```csharp


### PR DESCRIPTION
Added this to the Quick Start section of the readme document.
- Run scriptcs -install Microsoft.AspNet.WebApi.SelfHost

This is the better way of installing Nuget packages.
