### PR TITLE
Allow installation of prerelease packages without requiring a valid version to be specified.

### DIFF
--- a/src/ScriptCs.Core/Package/InstallationProvider/NugetInstallationProvider.cs
+++ b/src/ScriptCs.Core/Package/InstallationProvider/NugetInstallationProvider.cs
@@ -62,7 +62,7 @@ namespace ScriptCs.Package.InstallationProvider
                 }
                 else
                 {
-                    _manager.InstallPackage(packageId.PackageId);
+                    _manager.InstallPackage(packageId.PackageId, null, false, allowPreRelease);
                 }
 
                 if (packageInstalled != null)


### PR DESCRIPTION
InstallCommand should not ignore the allowPreRelease flag if a version is not explicitly specified by the user.

Fixes #252.
