### PR TITLE
Added missing method call to IConsole.Exit().

### DIFF
--- a/src/ScriptCs/Repl.cs
+++ b/src/ScriptCs/Repl.cs
@@ -49,6 +49,8 @@ namespace ScriptCs
         {
             Logger.Debug("Terminating packs");
             ScriptPackSession.TerminatePacks();
+            Logger.Debug("Exiting console");
+            Console.Exit();
         }
 
         public void Execute(string script)

--- a/test/ScriptCs.Tests/ReplTests.cs
+++ b/test/ScriptCs.Tests/ReplTests.cs
@@ -114,6 +114,12 @@ namespace ScriptCs.Tests
             {
                 _mocks.ScriptPack.Verify(x => x.Terminate());
             }
+
+            [Fact]
+            public void ExitsTheConsole()
+            {
+                _mocks.Console.Verify(x => x.Exit());
+            }
         }
 
         public class TheExecuteMethod


### PR DESCRIPTION
Fix for #267
