### PR TITLE
Implemented ability to pass arguments to the script

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,48 @@ var result = runner.Run(new ConsoleListener(msg => Console.WriteLine(msg)), Test
 Console.ReadKey();
 ```
 
+### Passing arguments to the script
+
+You can pass any additional arguments to the script by using `-args` command-line switch:
+
+```batchfile
+scriptcs deploy.csx -args "Dev -label 'Next Week RC' -version 1110 -force"
+```
+
+Argument parsing is done by using excellent [PowerArgs](https://github.com/adamabdelhamed/PowerArgs) library, so you just need to declare class, similar to the one below (see [PowerArgs](https://github.com/adamabdelhamed/PowerArgs) documentation), to get your arguments inside the script:
+
+```c#
+public class DeployArgs
+{
+	[ArgPosition(0)]
+	[ArgDescription("Environment code")]
+	public string Environment { get; set; }
+
+	[ArgShortcut("label")]
+	[ArgDescription("Deployment label")]
+	public string Label { get; set; }
+
+	[ArgShortcut("version")]
+	[ArgDescription("Version to deploy")]
+	public int Version { get; set; }
+
+	[ArgShortcut("force")]
+	[ArgDescription("Forces re-deployment")]
+	public bool Force { get; set; }
+}
+
+var args = Args<DeployArgs>();
+Console.WriteLine(args.Environment);
+Console.WriteLine(args.Label);
+Console.WriteLine(args.Version);
+Console.WriteLine(args.Force);
+```
+You can also get raw command-line input if you'd like to parse script arguments yourself:
+
+```c#
+var args = Args();
+Console.WriteLine(args);
+```
 
 ## Contributing
 

--- a/src/ScriptCs.Core/IScriptEngine.cs
+++ b/src/ScriptCs.Core/IScriptEngine.cs
@@ -5,6 +5,6 @@ namespace ScriptCs
     public interface IScriptEngine
     {
         string BaseDirectory { get; set; }
-        object Execute(string code, IEnumerable<string> references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession);
+        object Execute(string code, string args, IEnumerable<string> references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession);
     }
 }

--- a/src/ScriptCs.Core/IScriptExecutor.cs
+++ b/src/ScriptCs.Core/IScriptExecutor.cs
@@ -5,6 +5,6 @@ namespace ScriptCs
 {
     public interface IScriptExecutor
     {
-        void Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> recipes);
+        void Execute(string script, string args, IEnumerable<string> paths, IEnumerable<IScriptPack> recipes);
     }
 }

--- a/src/ScriptCs.Core/IScriptHostFactory.cs
+++ b/src/ScriptCs.Core/IScriptHostFactory.cs
@@ -1,11 +1,7 @@
-﻿using System.Collections.Generic;
-
-using ScriptCs.Contracts;
-
-namespace ScriptCs
+﻿namespace ScriptCs
 {
-	public interface IScriptHostFactory
-	{
-		ScriptHost CreateScriptHost(IScriptPackManager scriptPackManager);
-	}
+    public interface IScriptHostFactory
+    {
+        ScriptHost CreateScriptHost(string scriptArgs, IScriptPackManager scriptPackManager);
+    }
 }

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -29,6 +29,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Nuget.Core.2.2.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
+    <Reference Include="PowerArgs">
+      <HintPath>..\..\packages\PowerArgs.1.6.0.0\lib\net40\PowerArgs.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -24,7 +24,7 @@ namespace ScriptCs
             _logger = logger;
         }
 
-        public void Execute(string script, IEnumerable<string> paths, IEnumerable<IScriptPack> scriptPacks)
+        public void Execute(string script, string args, IEnumerable<string> paths, IEnumerable<IScriptPack> scriptPacks)
         {
             var bin = Path.Combine(_fileSystem.GetWorkingDirectory(script), "bin");
 
@@ -42,7 +42,7 @@ namespace ScriptCs
             var references = DefaultReferences.Union(paths).Union(result.References);
 
             _logger.Debug("Starting execution in engine");
-            _scriptEngine.Execute(result.Code, references, DefaultNamespaces, scriptPackSession);
+            _scriptEngine.Execute(result.Code, args, references, DefaultNamespaces, scriptPackSession);
 
             _logger.Debug("Terminating packs");
             scriptPackSession.TerminatePacks();

--- a/src/ScriptCs.Core/ScriptHost.cs
+++ b/src/ScriptCs.Core/ScriptHost.cs
@@ -1,22 +1,68 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+using PowerArgs;
 
 using ScriptCs.Contracts;
+using ScriptCs.Exceptions;
 
 namespace ScriptCs
 {
     public class ScriptHost
     {
-        private IScriptPackManager _scriptPackManager;
+        readonly string _scriptArgs;
+        readonly IScriptPackManager _scriptPackManager;
 
-        public ScriptHost(IScriptPackManager scriptPackManager)
+        object _parsedArgs;
+
+        public ScriptHost(string scriptArgs, IScriptPackManager scriptPackManager)
         {
+            _scriptArgs = scriptArgs ?? "";
             _scriptPackManager = scriptPackManager;
         }
 
-        public T Require<T>() where T:IScriptPackContext
+        public T Require<T>() where T : IScriptPackContext
         {
             return _scriptPackManager.Get<T>();
         }
 
+        public string Args()
+        {
+            return _scriptArgs;
+        }
+
+        public TArgs Args<TArgs>() where TArgs : class, new()
+        {
+            if (_parsedArgs == null)
+                _parsedArgs = Args() != "" ? TryParseArgs<TArgs>() : new TArgs();
+
+            return (TArgs) _parsedArgs;
+        }
+
+        TArgs TryParseArgs<TArgs>() where TArgs : class, new()
+        {
+            try
+            {
+                return PowerArgs.Args.Parse<TArgs>(SplitArgs());
+            }
+            catch (ArgException)
+            {
+                var options = new ArgUsageOptions {ShowPosition = false, ShowType = false};
+                var usage = ArgUsage.GetUsage<TArgs>(options: options);
+
+                throw new ScriptExecutionException("Wrong script arguments. See usage below\n\n" + usage);
+            }
+        }
+
+        string[] SplitArgs()
+        {
+            var regex = new Regex(@"(--?[\w]+)[:\s=]?([\w]:(?:\\[\w\s-]+)+\\?(?=\s-)|'[^']*'|[^-][^\s]*)?");
+
+            return regex.Split(Args())
+                        .Where(arg => !string.IsNullOrWhiteSpace(arg))
+                        .Select(arg => arg.TrimEnd(' ').Trim('\''))
+                        .ToArray();
+        }
     }
 }

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -1,13 +1,10 @@
-﻿using System.Collections.Generic;
-using ScriptCs.Contracts;
-
-namespace ScriptCs
+﻿namespace ScriptCs
 {
     public class ScriptHostFactory : IScriptHostFactory
     {
-        public ScriptHost CreateScriptHost(IScriptPackManager scriptPackManager)
+        public ScriptHost CreateScriptHost(string scriptArgs, IScriptPackManager scriptPackManager)
         {
-            return new ScriptHost(scriptPackManager);
+            return new ScriptHost(scriptArgs, scriptPackManager);
         }
     }
 }

--- a/src/ScriptCs.Core/packages.config
+++ b/src/ScriptCs.Core/packages.config
@@ -6,4 +6,5 @@
   <!-- NOTE (adamralph): when NuGet 2.7 is released we can just add developmentDependency="true" -->
   <!--package id="LiteGuard.Source" version="0.6.0" targetFramework="net45" />-->
   <package id="Nuget.Core" version="2.2.0" targetFramework="net45" />
+  <package id="PowerArgs" version="1.6.0.0" targetFramework="net45" />
 </packages>

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -1,7 +1,12 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using Common.Logging;
+
+using Roslyn.Compilers;
+using Roslyn.Compilers.CSharp;
 using Roslyn.Scripting;
 using Roslyn.Scripting.CSharp;
 
@@ -28,7 +33,7 @@ namespace ScriptCs.Engine.Roslyn
             set {  _scriptEngine.BaseDirectory = value; }
         }
 
-        public object Execute(string code, IEnumerable<string> references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession)
+        public object Execute(string code, string args, IEnumerable<string> references, IEnumerable<string> namespaces, ScriptPackSession scriptPackSession)
         {
             Guard.AgainstNullArgument("scriptPackSession", scriptPackSession);
 
@@ -40,7 +45,7 @@ namespace ScriptCs.Engine.Roslyn
 
             if (!scriptPackSession.State.ContainsKey(SessionKey))
             {
-                var host = _scriptHostFactory.CreateScriptHost(new ScriptPackManager(scriptPackSession.Contexts));
+                var host = _scriptHostFactory.CreateScriptHost(args, new ScriptPackManager(scriptPackSession.Contexts));
                 _logger.Debug("Creating session");
                 var session = _scriptEngine.CreateSession(host);
 
@@ -55,6 +60,9 @@ namespace ScriptCs.Engine.Roslyn
                     _logger.DebugFormat("Importing namespace {0}", @namespace);
                     session.ImportNamespace(@namespace);
                 }
+
+                session.AddReference(new MetadataFileReference(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "PowerArgs.dll")));
+                session.ImportNamespace("PowerArgs");
 
                 sessionState = new SessionState<Session> {References = distinctReferences, Session = session};
                 scriptPackSession.State[SessionKey] = sessionState;

--- a/src/ScriptCs/Command/CommandFactory.cs
+++ b/src/ScriptCs/Command/CommandFactory.cs
@@ -32,7 +32,7 @@ namespace ScriptCs.Command
             if (args.ScriptName != null)
             {
                 var executeCommand = new ExecuteScriptCommand(
-                    args.ScriptName, 
+                    args.ScriptName, args.ScriptArgs,
                     _scriptServiceRoot.FileSystem, 
                     _scriptServiceRoot.Executor,
                     _scriptServiceRoot.ScriptPackResolver,

--- a/src/ScriptCs/Command/ExecuteScriptCommand.cs
+++ b/src/ScriptCs/Command/ExecuteScriptCommand.cs
@@ -10,6 +10,7 @@ namespace ScriptCs.Command
     internal class ExecuteScriptCommand : IScriptCommand
     {
         private readonly string _script;
+        private readonly string _args;
         private readonly IFileSystem _fileSystem;
         private readonly IScriptExecutor _scriptExecutor;
         private readonly IScriptPackResolver _scriptPackResolver;
@@ -17,7 +18,7 @@ namespace ScriptCs.Command
 
         private readonly ILog _logger;
 
-        public ExecuteScriptCommand(string script, 
+        public ExecuteScriptCommand(string script, string args, 
             IFileSystem fileSystem, 
             IScriptExecutor scriptExecutor, 
             IScriptPackResolver scriptPackResolver,
@@ -25,6 +26,7 @@ namespace ScriptCs.Command
             IAssemblyName assemblyName)
         {
             _script = script;
+            _args = args;
             _fileSystem = fileSystem;
             _scriptExecutor = scriptExecutor;
             _scriptPackResolver = scriptPackResolver;
@@ -44,7 +46,7 @@ namespace ScriptCs.Command
                     assemblyPaths = GetAssemblyPaths(workingDirectory);
                 }
 
-                _scriptExecutor.Execute(_script, assemblyPaths, _scriptPackResolver.GetPacks());
+                _scriptExecutor.Execute(_script, _args, assemblyPaths, _scriptPackResolver.GetPacks());
                 return CommandResult.Success;
             }
             catch (Exception ex)

--- a/src/ScriptCs/Repl.cs
+++ b/src/ScriptCs/Repl.cs
@@ -86,7 +86,7 @@ namespace ScriptCs
                 }
 
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                var result = ScriptEngine.Execute(script, References, DefaultNamespaces, ScriptPackSession);
+                var result = ScriptEngine.Execute(script, "", References, DefaultNamespaces, ScriptPackSession);
                 if (result != null)
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;

--- a/src/ScriptCs/ScriptCsArgs.cs
+++ b/src/ScriptCs/ScriptCsArgs.cs
@@ -12,9 +12,12 @@ namespace ScriptCs
         [ArgDescription("Script file name, must be specified first")]
         public string ScriptName { get; set; }
 
-        [ArgDescription("Displays help")]
-        
+        [ArgShortcut("args")]
+        [ArgDescription("Passes specified argument string to the script")]
+        public string ScriptArgs { get; set; }
+
         [ArgShortcut("?")]
+        [ArgDescription("Displays help")]
         public bool Help { get; set; }
 
         [ArgShortcut("debug")]

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -19,6 +19,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Nuget.Core.2.2.0\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
+    <Reference Include="PowerArgs, Version=1.6.0.0, Culture=neutral, PublicKeyToken=54832990a0812961, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\PowerArgs.1.6.0.0\lib\net40\PowerArgs.dll</HintPath>
+    </Reference>
     <Reference Include="Roslyn.Compilers, Version=1.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL" />
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.12.0\lib\Should.dll</HintPath>

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -50,7 +50,7 @@ namespace ScriptCs.Tests
 
                 var executor = CreateScriptExecutor(fileSystem: fileSystem, fileProcessor: preProcessor);
 
-                executor.Execute("script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
+                executor.Execute("script.csx", "", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
                 preProcessor.Verify(p => p.ProcessFile(@"c:\my_script\script.csx"));
             }
 
@@ -65,7 +65,7 @@ namespace ScriptCs.Tests
                 preProcessor.Setup(p => p.ProcessFile(It.IsAny<string>())).Returns(new FilePreProcessorResult { Code = "var a = 0;" });
 
                 var executor = CreateScriptExecutor(fileSystem: fileSystem, fileProcessor: preProcessor);
-                executor.Execute(@"c:\my_script\script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
+                executor.Execute(@"c:\my_script\script.csx", "", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
 
                 preProcessor.Verify(p => p.ProcessFile(@"c:\my_script\script.csx"));
             }
@@ -92,7 +92,7 @@ namespace ScriptCs.Tests
                 IEnumerable<IScriptPack> recipes = Enumerable.Empty<IScriptPack>();
 
                 // act
-                scriptExecutor.Execute(scriptName, paths, recipes);
+                scriptExecutor.Execute(scriptName, "", paths, recipes);
 
                 // assert
                 string expectedBaseDirectory = Path.Combine(currentDirectory, "bin");
@@ -123,15 +123,15 @@ namespace ScriptCs.Tests
                 var recipes = Enumerable.Empty<IScriptPack>();
 
                 preProcessor.Setup(fs => fs.ProcessFile(Path.Combine(currentDirectory, scriptName))).Returns(new FilePreProcessorResult { Code = code }).Verifiable();
-                scriptEngine.Setup(e => e.Execute(code, It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()));
+                scriptEngine.Setup(e => e.Execute(code, "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()));
 
                 // act
-                scriptExecutor.Execute(scriptName, paths, recipes);
+                scriptExecutor.Execute(scriptName, "", paths, recipes);
 
                 // assert
                 preProcessor.Verify(fs => fs.ProcessFile(Path.Combine(currentDirectory, scriptName)), Times.Once());
 
-                scriptEngine.Verify(s => s.Execute(code, It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
+                scriptEngine.Verify(s => s.Execute(code, "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
 
             }
 
@@ -162,13 +162,13 @@ namespace ScriptCs.Tests
 
                 var destPaths = new string[] { "System", "System.Core", destinationFilePath1, destinationFilePath2, destinationFilePath3, destinationFilePath4 };
 
-                scriptEngine.Setup(e => e.Execute(It.IsAny<string>(), It.Is<IEnumerable<string>>(x => x.SequenceEqual(defaultReferences.Union(destPaths))), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()));
+                scriptEngine.Setup(e => e.Execute(It.IsAny<string>(), "", It.Is<IEnumerable<string>>(x => x.SequenceEqual(defaultReferences.Union(destPaths))), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()));
 
                 // act
-                scriptExecutor.Execute(scriptName, paths, Enumerable.Empty<IScriptPack>());
+                scriptExecutor.Execute(scriptName, "", paths, Enumerable.Empty<IScriptPack>());
 
                 // assert
-                scriptEngine.Verify(e => e.Execute(It.IsAny<string>(), It.Is<IEnumerable<string>>(x => x.SequenceEqual(defaultReferences.Union(destPaths))), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
+                scriptEngine.Verify(e => e.Execute(It.IsAny<string>(), "", It.Is<IEnumerable<string>>(x => x.SequenceEqual(defaultReferences.Union(destPaths))), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
             }
 
             [Fact]
@@ -187,7 +187,7 @@ namespace ScriptCs.Tests
                 scriptPack1.Setup(p => p.Initialize(It.IsAny<IScriptPackSession>()));
                 scriptPack1.Setup(p => p.GetContext()).Returns(Mock.Of<IScriptPackContext>());
 
-                executor.Execute("script.csx", Enumerable.Empty<string>(), new[] { scriptPack1.Object });
+                executor.Execute("script.csx", "", Enumerable.Empty<string>(), new[] { scriptPack1.Object });
 
                 scriptPack1.Verify(p => p.Initialize(It.IsAny<IScriptPackSession>()));
             }
@@ -209,7 +209,7 @@ namespace ScriptCs.Tests
                 scriptPack1.Setup(p => p.GetContext()).Returns(Mock.Of<IScriptPackContext>());
                 scriptPack1.Setup(p => p.Terminate());
 
-                executor.Execute("script.csx", Enumerable.Empty<string>(), new[] { scriptPack1.Object });
+                executor.Execute("script.csx", "", Enumerable.Empty<string>(), new[] { scriptPack1.Object });
 
                 scriptPack1.Verify(p => p.Terminate());
             }
@@ -230,9 +230,9 @@ namespace ScriptCs.Tests
 
                 var executor = CreateScriptExecutor(fileSystem: fileSystem, fileProcessor: preProcessor, scriptEngine: engine);
 
-                executor.Execute("script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
+                executor.Execute("script.csx", "", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
 
-                engine.Verify(i => i.Execute(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.Is<IEnumerable<string>>(x => !x.Except(expectedNamespaces).Any()), It.IsAny<ScriptPackSession>()), Times.Exactly(1));
+                engine.Verify(i => i.Execute(It.IsAny<string>(), "", It.IsAny<IEnumerable<string>>(), It.Is<IEnumerable<string>>(x => !x.Except(expectedNamespaces).Any()), It.IsAny<ScriptPackSession>()), Times.Exactly(1));
             }
 
             [Fact]
@@ -251,9 +251,9 @@ namespace ScriptCs.Tests
 
                 var executor = CreateScriptExecutor(fileSystem: fileSystem, fileProcessor: preProcessor, scriptEngine: engine);
 
-                executor.Execute("script.csx", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
+                executor.Execute("script.csx", "", Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
 
-                engine.Verify(i => i.Execute(It.IsAny<string>(), It.Is<IEnumerable<string>>(x => !x.Except(defaultReferences).Any()), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Exactly(1));
+                engine.Verify(i => i.Execute(It.IsAny<string>(), "", It.Is<IEnumerable<string>>(x => !x.Except(defaultReferences).Any()), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Exactly(1));
             }
         }
     }

--- a/test/ScriptCs.Core.Tests/ScriptHostTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptHostTests.cs
@@ -8,6 +8,7 @@ using ScriptCs;
 using Xunit;
 using Should;
 using Moq;
+using PowerArgs;
 
 namespace ScriptCs.Tests
 {
@@ -21,15 +22,45 @@ namespace ScriptCs.Tests
 
             public TheGetMethod()
             {
-                _scriptHost = new ScriptHost(_mockScriptPackManager.Object);
+                _scriptHost = new ScriptHost("", _mockScriptPackManager.Object);
                 _mockScriptPackManager.Setup(s => s.Get<IScriptPackContext>()).Returns(_mockContext.Object);
             }
 
             [Fact]
-            public void ShoulGetScriptPackFromScriptPackManagerWhenInvoked()
+            public void ShouldGetScriptPackFromScriptPackManagerWhenInvoked()
             {
                 var result = _scriptHost.Require<IScriptPackContext>();
                 _mockScriptPackManager.Verify(s=>s.Get<IScriptPackContext>());
+            }
+
+            [Fact]
+            public void ShouldReturnEmptyArgumentStringIfNull()
+            {
+                var host = new ScriptHost(null, null);
+                Assert.Equal("", host.Args());
+            }
+
+            [Fact]
+            public void ShouldReturnParsedArgumentStringUsingPowerArgs()
+            {
+                var host = new ScriptHost("'Josh Wink' -version 1111 -f", null);
+                Assert.Equal("Josh Wink", host.Args<TestArgs>().Name);
+                Assert.Equal(1111, host.Args<TestArgs>().Version);
+            }
+
+            public class TestArgs
+            {
+                [ArgPosition(0)]
+                [ArgDescription("Positional arg")]
+                public string Name { get;set; }
+
+                [ArgShortcut("version")]
+                [ArgDescription("Named arg with required value")]
+                public int Version { get; set;}
+
+                [ArgShortcut("f")]
+                [ArgDescription("Named flag")]
+                public bool Flag { get;set; }
             }
         }
     }

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Moq" version="4.0.10827" targetFramework="net45" />
   <package id="Nuget.Core" version="2.2.0" targetFramework="net45" />
+  <package id="PowerArgs" version="1.6.0.0" targetFramework="net45" />
   <package id="Should" version="1.1.12.0" targetFramework="net45" />
   <package id="xunit" version="1.9.1" targetFramework="net45" />
 </packages>

--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptDebuggerEngine.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptDebuggerEngine.cs
@@ -38,7 +38,7 @@ namespace ScriptCs.Tests
                 var exception = Assert.Throws<ScriptExecutionException>(
                     () =>
                     scriptEngine.Execute(
-                        code, Enumerable.Empty<string>(), Enumerable.Empty<string>(), new ScriptPackSession(Enumerable.Empty<IScriptPack>())));
+                        code, "", Enumerable.Empty<string>(), Enumerable.Empty<string>(), new ScriptPackSession(Enumerable.Empty<IScriptPack>())));
 
                 Console.WriteLine(exception.Message);
 

--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
@@ -54,7 +54,7 @@ namespace ScriptCs.Tests
             public void ShouldCreateScriptHostWithContexts()
             {
                 var scriptHostFactory = new Mock<IScriptHostFactory>();
-                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>())).Returns((IScriptPackManager p) => new ScriptHost(p));
+                scriptHostFactory.Setup(f => f.CreateScriptHost("", It.IsAny<IScriptPackManager>())).Returns((string args, IScriptPackManager p) => new ScriptHost(args, p));
 
                 var code = "var a = 0;";
 
@@ -65,17 +65,17 @@ namespace ScriptCs.Tests
                 scriptPack1.Setup(p => p.GetContext()).Returns((IScriptPackContext)null);
 
                 var scriptPackSession = new ScriptPackSession(new[] { scriptPack1.Object });
-    
-                engine.Execute(code, Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
 
-                scriptHostFactory.Verify(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>()));
+                engine.Execute(code, "", Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
+
+                scriptHostFactory.Verify(f => f.CreateScriptHost("", It.IsAny<IScriptPackManager>()));
             }
 
             [Fact]
             public void ShouldReuseExistingSessionIfProvided()
             {
                 var scriptHostFactory = new Mock<IScriptHostFactory>();
-                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>())).Returns((IScriptPackManager p) => new ScriptHost(p));
+                scriptHostFactory.Setup(f => f.CreateScriptHost("", It.IsAny<IScriptPackManager>())).Returns((string args, IScriptPackManager p) => new ScriptHost(args, p));
 
                 var code = "var a = 0;";
 
@@ -84,7 +84,7 @@ namespace ScriptCs.Tests
                 var roslynEngine = new ScriptEngine();
                 var session = new SessionState<Session> {Session = roslynEngine.CreateSession()};
                 scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                engine.Execute(code, Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
+                engine.Execute(code, "", Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
                 engine.Session.ShouldEqual(session.Session);
             }
 
@@ -92,13 +92,13 @@ namespace ScriptCs.Tests
             public void ShouldCreateNewSessionIfNotProvided()
             {
                 var scriptHostFactory = new Mock<IScriptHostFactory>();
-                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>())).Returns((IScriptPackManager p) => new ScriptHost(p));
+                scriptHostFactory.Setup(f => f.CreateScriptHost("", It.IsAny<IScriptPackManager>())).Returns((string args, IScriptPackManager p) => new ScriptHost(args, p));
 
                 var code = "var a = 0;";
 
                 var engine = CreateTestScriptEngine(scriptHostFactory: scriptHostFactory);
                 var scriptPackSession = new ScriptPackSession(new List<IScriptPack>());
-                engine.Execute(code, Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
+                engine.Execute(code, "", Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
                 engine.Session.ShouldNotBeNull();
             }
 
@@ -106,7 +106,7 @@ namespace ScriptCs.Tests
             public void ShouldAddNewReferencesIfTheyAreProvided()
             {
                 var scriptHostFactory = new Mock<IScriptHostFactory>();
-                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>())).Returns((IScriptPackManager p) => new ScriptHost(p));
+                scriptHostFactory.Setup(f => f.CreateScriptHost("", It.IsAny<IScriptPackManager>())).Returns((string args, IScriptPackManager p) => new ScriptHost(args, p));
 
                 var code = "var a = 0;";
 
@@ -115,7 +115,7 @@ namespace ScriptCs.Tests
                 var roslynEngine = new ScriptEngine();
                 var session = new SessionState<Session> { Session = roslynEngine.CreateSession()};
                 scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                engine.Execute(code, new[] {"System"}, Enumerable.Empty<string>(), scriptPackSession);
+                engine.Execute(code, "", new[] {"System"}, Enumerable.Empty<string>(), scriptPackSession);
                 
                 ((SessionState<Session>)scriptPackSession.State[RoslynScriptEngine.SessionKey]).References.Count().ShouldEqual(1);
             }

--- a/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
@@ -41,7 +41,7 @@ namespace ScriptCs.Tests
 
                 result.Execute();
 
-                executor.Verify(i => i.Execute(It.Is<string>(x => x == "test.csx"), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
+                executor.Verify(i => i.Execute(It.Is<string>(x => x == "test.csx"), null, It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
             }
 
             [Fact]
@@ -111,7 +111,7 @@ namespace ScriptCs.Tests
 
                 result.Execute();
 
-                executor.Verify(i => i.Execute(It.IsAny<string>(), It.Is<IEnumerable<string>>(x => !x.Contains(nonManaged)), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
+                executor.Verify(i => i.Execute(It.IsAny<string>(), It.IsAny<string>(), It.Is<IEnumerable<string>>(x => !x.Contains(nonManaged)), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
             }
         }
     }

--- a/test/ScriptCs.Tests/ReplTests.cs
+++ b/test/ScriptCs.Tests/ReplTests.cs
@@ -150,15 +150,15 @@ namespace ScriptCs.Tests
             [Fact]
             public void CallsExecuteOnTheScriptEngine()
             {
-                _mocks.ScriptEngine.Verify(x => x.Execute("foo", _repl.References, Repl.DefaultNamespaces, It.IsAny<ScriptPackSession>()));
+                _mocks.ScriptEngine.Verify(x=>x.Execute("foo", "", _repl.References, Repl.DefaultNamespaces, It.IsAny<ScriptPackSession>()));
             }
 
             [Fact]
             public void CatchesExceptionsAndWritesThemInRed()
             {
                 _mocks.ScriptEngine.Setup(
-                    x => x.Execute(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()))
-                      .Throws<ArgumentException>();
+                    x => x.Execute(It.IsAny<string>(), "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()))
+                    .Throws<ArgumentException>();
 
                 _repl.Execute("foo");
 
@@ -196,7 +196,7 @@ namespace ScriptCs.Tests
                 _repl = GetRepl(mocks);
                 _repl.Execute("#load \"file.csx\"");
 
-                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
+                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Once());
             }
 
             [Fact]
@@ -208,7 +208,7 @@ namespace ScriptCs.Tests
                 _repl = GetRepl(mocks);
                 _repl.Execute("#load \"file.csx\"");
 
-                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Never());
+                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Never());
             }
 
             [Fact]
@@ -250,7 +250,7 @@ namespace ScriptCs.Tests
                 _repl.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
                 _repl.Execute("#r \"my.dll\"");
 
-                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Never());
+                mocks.ScriptEngine.Verify(i => i.Execute(It.IsAny<string>(), "", It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()), Times.Never());
             }
         }
     }


### PR DESCRIPTION
Hi guys!

Hope that I didn't do anything criminal with that :) Please comment if you have any objections or suggestions how to improve that feature.

I thought that using PowerArgs might be an excellent choice here (but sure, no support for dynamic in Roslyn CTP is a pity :( ). I don't know whether extending ScriptHost was a good idea, but I haven't found any other non-clunky way, to advertise this feature to the script. 

See usage example here https://github.com/yevhen/scriptcs/tree/script_args#passing-arguments-to-the-script

P.S. Eager to hear your comments !

Thanks,
Yevhen
