### PR TITLE
exported IConsole and ILog from Autofac to MEF Extensions

### DIFF
--- a/src/ScriptCs/CompositionRoot.cs
+++ b/src/ScriptCs/CompositionRoot.cs
@@ -4,6 +4,7 @@ using System.IO;
 using Autofac;
 using Autofac.Integration.Mef;
 using Common.Logging;
+using ScriptCs.Contracts;
 using ScriptCs.Engine.Roslyn;
 using ScriptCs.Package;
 using ScriptCs.Package.InstallationProvider;
@@ -35,7 +36,8 @@ namespace ScriptCs
             loggerConfigurator.Configure();
             var logger = loggerConfigurator.GetLogger();
 
-            builder.RegisterInstance<ILog>(logger);
+            builder.RegisterInstance<ILog>(logger).Exported(x => x.As<ILog>());
+            builder.RegisterType<ReplConsole>().As<IConsole>().Exported(x => x.As<IConsole>());
 
             var types = new[]
                 {
@@ -47,7 +49,6 @@ namespace ScriptCs
                     typeof (ScriptPackResolver),
                     typeof (NugetInstallationProvider),
                     typeof (PackageInstaller),
-                    typeof (ReplConsole),
                     typeof (AssemblyName)
                 };
 


### PR DESCRIPTION
Autofac does not automatically export components to MEF extensions - it needs to be specified explicitly.

Sine we'd like to give script pack authors ability to use `ILog` and `IConsole` in the script packs, added explicit export of these two interfaces.

You can now do this as a script pack author:

```
public class TestContext : IScriptPackContext
{
    private readonly ILog _logger;
    private readonly IConsole _console;

    public TestContext(ILog logger, IConsole console)
    {
        _logger = logger;
        _console = console;
    }

    public void Hello()
    {
        _logger.Info("Writing hello!");
        _console.WriteLine("Hello");
    }
}

public class TestPack : ScriptPack<TestContext>
{
    [ImportingConstructor]
    public TestPack(ILog logger, IConsole console)
    {
        Context = new TestContext(logger, console);
    }
}
```
