### PR TITLE
Fixes #321 `FileSystem.GetWorkingDirectory` FileNotFound exception.

### DIFF
--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -93,14 +93,22 @@ namespace ScriptCs
 
         public string GetWorkingDirectory(string path)
         {
+            if (string.IsNullOrWhiteSpace(path))
+                return CurrentDirectory;
+
             var realPath = GetFullPath(path);
 
-            var attributes = File.GetAttributes(realPath);
+            if (FileExists(realPath) || DirectoryExists(realPath))
+            {
+                var attributes = File.GetAttributes(realPath);
 
-            if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
-                return realPath;
-            else
+                if ((attributes & FileAttributes.Directory) == FileAttributes.Directory)
+                    return realPath;
+                
                 return Path.GetDirectoryName(realPath);
+            }
+
+            return Path.GetDirectoryName(realPath);
         }
 
         public string GetFullPath(string path)

--- a/test/ScriptCs.Core.Tests/FileSystemTests.cs
+++ b/test/ScriptCs.Core.Tests/FileSystemTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using Should;
 using Xunit;
@@ -9,18 +10,18 @@ namespace ScriptCs.Tests
     {
         public class GetWorkingDirectoryMethod
         {
+            private readonly FileSystem _fileSystem = new FileSystem();
+
             [Fact]
             public void ShouldProperlyConstructWorkingDirectoryIfScriptIsRunFromRelativePath()
             {
-                const string pathToMyScriptFolder = @"..\my_script\";
+                const string pathToMyScriptFolder = @"..\my_script";
 
                 try
                 {
                     Directory.CreateDirectory(pathToMyScriptFolder);
 
-                    var fileSystem = new FileSystem();
-
-                    fileSystem.GetWorkingDirectory(pathToMyScriptFolder)
+                    _fileSystem.GetWorkingDirectory(pathToMyScriptFolder)
                               .ShouldEqual(Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, pathToMyScriptFolder)));
                 }
                 finally
@@ -28,6 +29,55 @@ namespace ScriptCs.Tests
                     if (Directory.Exists(pathToMyScriptFolder))
                         Directory.Delete(pathToMyScriptFolder);
                 }
+            }
+
+            [Fact]
+            public void ShouldReturnWorkingDirectoryIfPathIsInvalid()
+            {
+                var invalidPaths = new List<string> {"", " ", null};
+
+                foreach (var invalidPath in invalidPaths)
+                {
+                   _fileSystem.GetWorkingDirectory(invalidPath).ShouldEqual(_fileSystem.CurrentDirectory);
+                }
+            }
+
+            [Fact]
+            public void ReturnsCorrectWorkingDirectory()
+            {
+                string workingDir = Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @".\working_dir\"));
+                string existingDirectoryPath = Path.GetFullPath(Path.Combine(workingDir, @".\existing_dir\"));
+                string existingFilePath = Path.GetFullPath(Path.Combine(workingDir, @".\existing_file.txt"));
+
+                try
+                {
+                    Directory.CreateDirectory(workingDir);
+                    Directory.CreateDirectory(existingDirectoryPath);
+                    File.Create(existingFilePath).Dispose();
+
+                    _fileSystem.GetWorkingDirectory(existingDirectoryPath).ShouldEqual(existingDirectoryPath);
+                    _fileSystem.GetWorkingDirectory(existingFilePath).ShouldEqual(
+                        Path.GetFullPath(Path.Combine(Environment.CurrentDirectory, @".\working_dir")));
+                }
+                finally
+                {
+                    if (Directory.Exists(existingDirectoryPath))
+                        Directory.Delete(existingDirectoryPath);
+
+                    if (File.Exists(existingFilePath))
+                        File.Delete(existingFilePath);
+
+                    if (Directory.Exists(workingDir))
+                        Directory.Delete(workingDir);
+                }
+            }
+
+            [Fact]
+            public void ReturnsCorrectWorkingDirectoryIfPathDoesNotExist()
+            {
+                const string nonExistantFilePath = @"C:\working_dir\i_dont_exist.txt";
+
+                _fileSystem.GetWorkingDirectory(nonExistantFilePath).ShouldEqual(@"C:\working_dir");
             }
         }
     }


### PR DESCRIPTION
Fixes #321
- If the specified path is null/empty/whitespace then the current directory gets returned.
- If the path to the file/folder doesn't exist then the directory of that path is returned.

Perhaps someone would like to check my unit tests and code and then to offer some constructive criticism? :smile: 

Advice on how to test `scriptcs -install ScriptCs.AzureMobileServices` with XUnit would also be welcome if that is needed.
