### PR TITLE
Added support for ILog logging in REPL

### DIFF
--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -33,7 +33,7 @@ namespace ScriptCs.Engine.Roslyn
         {
             Guard.AgainstNullArgument("scriptPackSession", scriptPackSession);
 
-            _logger.Info("Starting to create execution components");
+            _logger.Debug("Starting to create execution components");
             _logger.Debug("Creating script host");
             
             var distinctReferences = references.Union(scriptPackSession.References).Distinct().ToList();
@@ -77,9 +77,9 @@ namespace ScriptCs.Engine.Roslyn
                 }
             }
 
-            _logger.Info("Starting execution");
+            _logger.Debug("Starting execution");
             var result = Execute(code, sessionState.Session);
-            _logger.Info("Finished execution");
+            _logger.Debug("Finished execution");
             return result;
         }
 

--- a/src/ScriptCs/CompositionRoot.cs
+++ b/src/ScriptCs/CompositionRoot.cs
@@ -34,13 +34,13 @@ namespace ScriptCs
         public void Initialize()
         {
             var builder = new ContainerBuilder();
+            builder.RegisterType<ReplConsole>().As<IConsole>().Exported(x => x.As<IConsole>());
 
             var loggerConfigurator = new LoggerConfigurator(_logLevel);
-            loggerConfigurator.Configure();
+            loggerConfigurator.Configure(new ReplConsole());
             var logger = loggerConfigurator.GetLogger();
 
             builder.RegisterInstance<ILog>(logger).Exported(x => x.As<ILog>());
-            builder.RegisterType<ReplConsole>().As<IConsole>().Exported(x => x.As<IConsole>());
 
             var types = new[]
                 {

--- a/src/ScriptCs/LoggerConfigurator.cs
+++ b/src/ScriptCs/LoggerConfigurator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
+using ScriptCs.Contracts;
 using log4net;
-using log4net.Appender;
 using log4net.Core;
 using log4net.Layout;
 using log4net.Repository.Hierarchy;
@@ -25,11 +25,11 @@ namespace ScriptCs
             _logLevel = logLevel;
         }
 
-        public void Configure()
+        public void Configure(IConsole console)
         {
             var hierarchy = (Hierarchy)LogManager.GetRepository();
             var logger = LogManager.GetLogger(LoggerName);
-            var consoleAppender = new ConsoleAppender
+            var consoleAppender = new ScriptcsConsoleAppender(console)
             {
                 Layout = new PatternLayout(GetLogPattern(_logLevel)),
                 Threshold = hierarchy.LevelMap[_logLevel.ToString().ToUpper(CultureInfo.CurrentCulture)]

--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -13,7 +13,7 @@ namespace ScriptCs
             string[] scriptArgs;
             ScriptCsArgs.SplitScriptArgs(ref args, out scriptArgs);
 
-            var commandArgs = ParseArguments(args) ?? new ScriptCsArgs { Repl = true };
+            var commandArgs = ParseArguments(args);
 
             var compositionRoot = new CompositionRoot(commandArgs);
             compositionRoot.Initialize();
@@ -35,11 +35,20 @@ namespace ScriptCs
         {
             const string UnexpectedArgumentMessage = "Unexpected Argument: ";
 
-            if (args.Length <= 0) return null;
+            //no args initialized REPL
+            if (args.Length <= 0) return new ScriptCsArgs { Repl = true, LogLevel = LogLevel.Info};
 
             try
             {
-                return Args.Parse<ScriptCsArgs>(args);
+                var scriptcsArgs = Args.Parse<ScriptCsArgs>(args);
+                
+                //if there is only 1 arg and it is a loglevel, it's also REPL
+                if (args.Length == 2 && args.Any(x => x.ToLowerInvariant() == "-log"))
+                {
+                    scriptcsArgs.Repl = true;
+                }
+
+                return scriptcsArgs;
             }
             catch (ArgException ex)
             {

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -77,6 +77,7 @@
     <Compile Include="LoggerConfigurator.cs" />
     <Compile Include="LogLevel.cs" />
     <Compile Include="ReplConsole.cs" />
+    <Compile Include="ScriptcsConsoleAppender.cs" />
     <Compile Include="ScriptServiceRoot.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ScriptCs/ScriptcsConsoleAppender.cs
+++ b/src/ScriptCs/ScriptcsConsoleAppender.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+using ScriptCs.Contracts;
+using log4net.Appender;
+using log4net.Core;
+
+namespace ScriptCs
+{
+    public class ScriptcsConsoleAppender : AppenderSkeleton
+    {
+        private readonly IConsole _console;
+
+        public ScriptcsConsoleAppender(IConsole console)
+        {
+            _console = console;
+        }
+
+        protected override void Append(LoggingEvent loggingEvent)
+        {
+            var txt = new StringBuilder();
+            txt.Append(loggingEvent.Level);
+            txt.Append(": ");
+            txt.Append(loggingEvent.RenderedMessage);
+            _console.WriteLine(txt.ToString());
+        }
+    }
+}


### PR DESCRIPTION
- fixes #320
- added ScriptcsConsoleAppender (to respect `IConsole`) instead of arbitrary Console output
- changed unnecessary info logging to debug
- REPL will now use IConsole for logging output
- you can now start REPL by passing logevel too. i.e. `scriptcs -log debug`
