### PR TITLE
Fix for parsing files with line breaks that differ from the host FileSys...

### DIFF
--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -78,7 +78,7 @@ namespace ScriptCs
 
         public IEnumerable<string> SplitLines(string value)
         {
-            return value.Split(new[] { NewLine }, StringSplitOptions.None);
+            return value.Split(new[] { "\r\n", "\n" }, StringSplitOptions.None);
         }
 
         public Stream CreateFileStream(string filePath, FileMode mode)


### PR DESCRIPTION
...tem

When working with files that have been downloaded to a machine, there is no guarantee that the line breaks actually match the host OS line breaks. This should allow consistent parsing regardless of the original source of the file.
