### PR TITLE
Updated the way persistent engine returns assembly

### DIFF
--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
@@ -2,16 +2,14 @@
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Common.Logging;
 using Roslyn.Scripting;
+using ScriptCs.Contracts;
 using ScriptCs.Exceptions;
 
 namespace ScriptCs.Engine.Roslyn
 {
-    using System.Runtime.ExceptionServices;
-
-    using ScriptCs.Contracts;
-
     public abstract class RoslynScriptCompilerEngine : RoslynScriptEngine
     {
         protected const string CompiledScriptClass = "Submission#0";
@@ -65,7 +63,10 @@ namespace ScriptCs.Engine.Roslyn
             if (compileSuccess)
             {
                 var assembly = this.LoadAssembly(exeBytes, pdbBytes);
+                
                 Logger.Debug("Retrieving compiled script class (reflection).");
+                
+                // the following line can throw NullReferenceException, if that happens it's useful to notify that an error ocurred
                 var type = assembly.GetType(CompiledScriptClass);
                 Logger.Debug("Retrieving compiled script method (reflection).");
                 var method = type.GetMethod(CompiledScriptMethod, BindingFlags.Static | BindingFlags.Public);

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
@@ -16,6 +16,9 @@ namespace ScriptCs.Engine.Roslyn
         protected override Assembly LoadAssembly(byte[] exeBytes, byte[] pdbBytes)
         {
             this.Logger.Debug("Loading assembly from memory.");
+
+            // this is required for debugging. otherwise, the .dll is not related to the .pdb
+            // there might be ways of doing this without "loading", haven't found one yet
             return AppDomain.CurrentDomain.Load(exeBytes, pdbBytes);
         }
     }

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -1,5 +1,7 @@
-﻿using System.Reflection;
+﻿using System;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 
 using Common.Logging;
 
@@ -9,7 +11,8 @@ namespace ScriptCs.Engine.Roslyn
 {
     public class RoslynScriptPersistentEngine : RoslynScriptCompilerEngine
     {
-        private IFileSystem _fileSystem;
+        private readonly IFileSystem _fileSystem;
+        private const string RoslynAssemblyNameCharacter = "ℛ";
 
         public RoslynScriptPersistentEngine(IScriptHostFactory scriptHostFactory, ILog logger, IFileSystem fileSystem)
             : base(scriptHostFactory, logger)
@@ -32,7 +35,9 @@ namespace ScriptCs.Engine.Roslyn
 
             this.Logger.DebugFormat("Loading assembly {0}.", dllPath);
 
-            return Assembly.LoadFrom(dllPath);
+            // the assembly is automatically loaded into the AppDomain when compiled
+            // just need to find and return it
+            return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName.StartsWith(RoslynAssemblyNameCharacter));
         }
     }
 }


### PR DESCRIPTION
Fixes #426.

When a compilation takes place with Roslyn, the assembly is automatically loaded into the app domain.
1. When loading from disk, we only need to find the assembly in the `AppDomain` an return it.
2. When running in memory, we need to relate the .pdb to the .dll to support debugging so a `Load` call is required.
