### PR TITLE
Moved DirectiveLineProcessor to Contracts

### DIFF
--- a/src/ScriptCs.Contracts/DirectiveLineProcessor.cs
+++ b/src/ScriptCs.Contracts/DirectiveLineProcessor.cs
@@ -1,6 +1,4 @@
-﻿using ScriptCs.Contracts;
-
-namespace ScriptCs
+﻿namespace ScriptCs.Contracts
 {
     public abstract class DirectiveLineProcessor : ILineProcessor
     {

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -19,6 +19,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DirectiveLineProcessor.cs" />
     <Compile Include="FileParserContext.cs" />
     <Compile Include="FilePreProcessorResult.cs" />
     <Compile Include="IAssemblyResolver.cs" />

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -28,7 +28,6 @@
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="AssemblyUtility.cs" />
     <Compile Include="DebugScriptExecutor.cs" />
-    <Compile Include="DirectiveLineProcessor.cs" />
     <Compile Include="Exceptions\ScriptExecutionException.cs" />
     <Compile Include="Exceptions\MissingAssemblyException.cs" />
     <Compile Include="..\..\common\CommonAssemblyInfo.cs">


### PR DESCRIPTION
When working on a module with some custom directive processors, I noticed that I had forgot to move the `DirectiveLineProcessor` class.
