### PR TITLE
Moved line processors to Contracts to be able to extend current implementation

### DIFF
--- a/src/ScriptCs.Contracts/ILoadLineProcessor.cs
+++ b/src/ScriptCs.Contracts/ILoadLineProcessor.cs
@@ -1,0 +1,6 @@
+﻿namespace ScriptCs.Contracts
+{
+    public interface ILoadLineProcessor : ILineProcessor
+    {
+    }
+}

--- a/src/ScriptCs.Contracts/IReferenceLineProcessor.cs
+++ b/src/ScriptCs.Contracts/IReferenceLineProcessor.cs
@@ -1,0 +1,6 @@
+﻿namespace ScriptCs.Contracts
+{
+    public interface IReferenceLineProcessor : ILineProcessor
+    {
+    }
+}

--- a/src/ScriptCs.Contracts/IUsingLineProcessor.cs
+++ b/src/ScriptCs.Contracts/IUsingLineProcessor.cs
@@ -1,0 +1,6 @@
+﻿namespace ScriptCs.Contracts
+{
+    public interface IUsingLineProcessor : ILineProcessor
+    {
+    }
+}

--- a/src/ScriptCs.Contracts/LoadLineProcessor.cs
+++ b/src/ScriptCs.Contracts/LoadLineProcessor.cs
@@ -1,13 +1,7 @@
 ﻿using System;
 
-using ScriptCs.Contracts;
-
-namespace ScriptCs
+namespace ScriptCs.Contracts
 {
-    public interface ILoadLineProcessor : ILineProcessor
-    {
-    }
-
     public class LoadLineProcessor : DirectiveLineProcessor, ILoadLineProcessor
     {
         private readonly IFileSystem _fileSystem;

--- a/src/ScriptCs.Contracts/ReferenceLineProcessor.cs
+++ b/src/ScriptCs.Contracts/ReferenceLineProcessor.cs
@@ -1,13 +1,7 @@
 ﻿using System;
-using System.IO;
-using ScriptCs.Contracts;
 
-namespace ScriptCs
+namespace ScriptCs.Contracts
 {
-    public interface IReferenceLineProcessor : ILineProcessor
-    {
-    }
-
     public class ReferenceLineProcessor : DirectiveLineProcessor, IReferenceLineProcessor
     {
         private readonly IFileSystem _fileSystem;

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -30,6 +30,7 @@
     <Compile Include="IFileSystem.cs" />
     <Compile Include="IInstallationProvider.cs" />
     <Compile Include="ILineProcessor.cs" />
+    <Compile Include="ILoadLineProcessor.cs" />
     <Compile Include="IModule.cs" />
     <Compile Include="IModuleConfiguration.cs" />
     <Compile Include="IModuleMetadata.cs" />
@@ -38,6 +39,7 @@
     <Compile Include="IPackageInstaller.cs" />
     <Compile Include="IPackageObject.cs" />
     <Compile Include="IPackageReference.cs" />
+    <Compile Include="IReferenceLineProcessor.cs" />
     <Compile Include="IScriptEngine.cs" />
     <Compile Include="IScriptExecutor.cs" />
     <Compile Include="IScriptHost.cs" />
@@ -54,12 +56,16 @@
       <Link>Properties\CommonVersionInfo.cs</Link>
     </Compile>
     <Compile Include="IServiceOverrides.cs" />
+    <Compile Include="IUsingLineProcessor.cs" />
+    <Compile Include="LoadLineProcessor.cs" />
     <Compile Include="LogLevel.cs" />
     <Compile Include="ModuleAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReferenceLineProcessor.cs" />
     <Compile Include="ScriptPack.cs" />
     <Compile Include="ScriptPackSession.cs" />
     <Compile Include="ScriptResult.cs" />
+    <Compile Include="UsingLineProcessor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\ScriptCs.Contracts.nuspec" />

--- a/src/ScriptCs.Contracts/UsingLineProcessor.cs
+++ b/src/ScriptCs.Contracts/UsingLineProcessor.cs
@@ -1,11 +1,5 @@
-﻿using ScriptCs.Contracts;
-
-namespace ScriptCs
+﻿namespace ScriptCs.Contracts
 {
-    public interface IUsingLineProcessor : ILineProcessor
-    {
-    }
-
     public class UsingLineProcessor : IUsingLineProcessor
     {
         private const string UsingString = "using ";

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -40,12 +40,10 @@
     <Compile Include="FileSystem.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="ILoggerConfigurator.cs" />
-    <Compile Include="LoadLineProcessor.cs" />
     <Compile Include="PackageAssemblyResolver.cs" />
     <Compile Include="Constants.cs" />
     <Compile Include="PackageReference.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="ReferenceLineProcessor.cs" />
     <Compile Include="Repl.cs" />
     <Compile Include="ScriptExecutorExtensions.cs" />
     <Compile Include="ScriptHost.cs" />
@@ -55,7 +53,6 @@
     <Compile Include="ScriptExecutor.cs" />
     <Compile Include="ScriptServices.cs" />
     <Compile Include="SessionState.cs" />
-    <Compile Include="UsingLineProcessor.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config">


### PR DESCRIPTION
This will allow modules to override/extend current implementation of `#load` or `#r` processing...
