### PR TITLE
Found package info should be at debug level

### DIFF
--- a/src/ScriptCs.Core/PackageAssemblyResolver.cs
+++ b/src/ScriptCs.Core/PackageAssemblyResolver.cs
@@ -118,7 +118,7 @@ namespace ScriptCs
                     }
 
                     foundAssemblies.Add(path);
-                    _logger.Info("Found: " + path);
+                    _logger.Debug("Found: " + path);
                 }
 
                 if (nugetPackage.Dependencies == null || !nugetPackage.Dependencies.Any() || !strictLoad)


### PR DESCRIPTION
This was discussed in the mailing list.
When package is found do not show them at INFO level.

![2013-09-18_2027](https://f.cloud.github.com/assets/1710369/1167528/67fb8a90-2090-11e3-8a47-46b330982398.png)
