### PR TITLE
Fix for #475

### DIFF
--- a/src/ScriptCs.Contracts/IAssemblyResolver.cs
+++ b/src/ScriptCs.Contracts/IAssemblyResolver.cs
@@ -4,6 +4,6 @@ namespace ScriptCs.Contracts
 {
     public interface IAssemblyResolver
     {
-        IEnumerable<string> GetAssemblyPaths(string path, string scriptName);
+        IEnumerable<string> GetAssemblyPaths(string path);
     }
 }

--- a/src/ScriptCs.Core/AssemblyResolver.cs
+++ b/src/ScriptCs.Core/AssemblyResolver.cs
@@ -32,7 +32,7 @@ namespace ScriptCs
             _assemblyUtility = assemblyUtility;
         }
 
-        public IEnumerable<string> GetAssemblyPaths(string path, string scriptName)
+        public IEnumerable<string> GetAssemblyPaths(string path)
         {
             Guard.AgainstNullArgument("path", path);
 
@@ -43,7 +43,7 @@ namespace ScriptCs
             }
 
             var packageAssemblies = GetPackageAssemblies(path);
-            var binAssemblies = GetBinAssemblies(path, scriptName);
+            var binAssemblies = GetBinAssemblies(path);
 
             assemblies = packageAssemblies.Union(binAssemblies).ToList();
             _assemblyPathCache.Add(path, assemblies);
@@ -51,7 +51,7 @@ namespace ScriptCs
             return assemblies;
         }
 
-        private IEnumerable<string> GetBinAssemblies(string path, string scriptName)
+        private IEnumerable<string> GetBinAssemblies(string path)
         {
             var binFolder = Path.Combine(path, Constants.BinFolder);
             if (!_fileSystem.DirectoryExists(binFolder))
@@ -59,11 +59,9 @@ namespace ScriptCs
                 return Enumerable.Empty<string>();
             }
 
-            var dllName = string.IsNullOrEmpty(scriptName) ? string.Empty : scriptName.Replace(Path.GetExtension(scriptName), ".dll");
-
             var assemblies = _fileSystem.EnumerateFiles(binFolder, "*.dll")
                 .Union(_fileSystem.EnumerateFiles(binFolder, "*.exe"))
-                .Where(f => _assemblyUtility.IsManagedAssembly(f) && !dllName.Equals(Path.GetFileName(f)))
+                .Where(f => _assemblyUtility.IsManagedAssembly(f) && !f.EndsWith(Constants.CompiledDllSuffix))
                 .ToList();
 
             foreach (var assembly in assemblies)

--- a/src/ScriptCs.Core/Constants.cs
+++ b/src/ScriptCs.Core/Constants.cs
@@ -9,5 +9,6 @@ namespace ScriptCs
         public const string DefaultRepositoryUrl = "https://nuget.org/api/v2/";
         public const string DebugContractName = "Debug";
         public const string RunContractName = "Run";
+        public const string CompiledDllSuffix = ".scriptcs.build.dll";
     }
 }

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -29,7 +29,7 @@ namespace ScriptCs.Engine.Roslyn
                 _fileSystem.CreateDirectory(BaseDirectory);
             }
 
-            var dllName = FileName.Replace(Path.GetExtension(FileName), ".dll");
+            var dllName = string.Format("{0}{1}", Path.GetFileNameWithoutExtension(FileName), Constants.CompiledDllSuffix);
             var dllPath = Path.Combine(BaseDirectory, dllName);
             _fileSystem.WriteAllBytes(dllPath, exeBytes);
 

--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -47,7 +47,7 @@ namespace ScriptCs
         public void Load(IModuleConfiguration config, string modulePackagesPath, string extension, params string[] moduleNames)
         {
             _logger.Debug("Loading modules from: " + modulePackagesPath);
-            var paths = _resolver.GetAssemblyPaths(modulePackagesPath, string.Empty);
+            var paths = _resolver.GetAssemblyPaths(modulePackagesPath);
             var catalog = new AggregateCatalog();
             foreach (var path in paths)
             {

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -65,7 +65,7 @@ namespace ScriptCs
             if (_initDirectoryCatalog)
             {
                 var currentDirectory = Environment.CurrentDirectory;
-                var assemblies = assemblyResolver.GetAssemblyPaths(currentDirectory, _scriptName);
+                var assemblies = assemblyResolver.GetAssemblyPaths(currentDirectory);
 
                 var aggregateCatalog = new AggregateCatalog();
 

--- a/src/ScriptCs/Command/ExecuteReplCommand.cs
+++ b/src/ScriptCs/Command/ExecuteReplCommand.cs
@@ -46,7 +46,7 @@ namespace ScriptCs.Command
             var repl = new Repl(_scriptArgs, _fileSystem, _scriptEngine, _logger, _console, _filePreProcessor);
 
             var workingDirectory = _fileSystem.CurrentDirectory;
-            var assemblies = _assemblyResolver.GetAssemblyPaths(workingDirectory, string.Empty);
+            var assemblies = _assemblyResolver.GetAssemblyPaths(workingDirectory);
             var scriptPacks = _scriptPackResolver.GetPacks();
 
             repl.Initialize(assemblies, scriptPacks, ScriptArgs);

--- a/src/ScriptCs/Command/ExecuteScriptCommand.cs
+++ b/src/ScriptCs/Command/ExecuteScriptCommand.cs
@@ -49,7 +49,7 @@ namespace ScriptCs.Command
                 var workingDirectory = _fileSystem.GetWorkingDirectory(_script);
                 if (workingDirectory != null)
                 {
-                    assemblyPaths = _assemblyResolver.GetAssemblyPaths(workingDirectory, _script);
+                    assemblyPaths = _assemblyResolver.GetAssemblyPaths(workingDirectory);
                 }
 
                 _scriptExecutor.Initialize(assemblyPaths, _scriptPackResolver.GetPacks(), ScriptArgs);

--- a/test/ScriptCs.Core.Tests/AssemblyResolverTests.cs
+++ b/test/ScriptCs.Core.Tests/AssemblyResolverTests.cs
@@ -34,7 +34,7 @@ namespace ScriptCs.Tests
 
                 var resolver = new AssemblyResolver(fileSystem.Object, packageAssemblyResolver.Object, Mock.Of<IAssemblyUtility>(), Mock.Of<ILog>());
 
-                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory, "script.csx").ToList();
+                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory).ToList();
 
                 assemblies.Count.ShouldEqual(1);
                 assemblies[0].ShouldEqual(assemblyFile);
@@ -57,7 +57,7 @@ namespace ScriptCs.Tests
 
                 var resolver = new AssemblyResolver(fileSystem.Object, Mock.Of<IPackageAssemblyResolver>(), assemblyUtility.Object, Mock.Of<ILog>());
 
-                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory, "script.csx").ToList();
+                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory).ToList();
 
                 assemblies.Count.ShouldEqual(1);
                 assemblies[0].ShouldEqual(assemblyFile);
@@ -83,19 +83,19 @@ namespace ScriptCs.Tests
 
                 var resolver = new AssemblyResolver(fileSystem.Object, Mock.Of<IPackageAssemblyResolver>(), assemblyUtility.Object, Mock.Of<ILog>());
 
-                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory, "script.csx").ToList();
+                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory).ToList();
 
                 assemblies.Count.ShouldEqual(1);
                 assemblies[0].ShouldEqual(managed);
             }
 
             [Fact]
-            public void ShouldNotReturnScriptDll()
+            public void ShouldNotReturnFilesThatMatchscriptcs_build_dllPattern()
             {
                 const string WorkingDirectory = @"C:\";
 
                 var binFolder = Path.Combine(WorkingDirectory, "bin");
-                var scriptDll = Path.Combine(binFolder, "script.dll");
+                var scriptDll = Path.Combine(binFolder, string.Format("myscript{0}", Constants.CompiledDllSuffix));
 
                 var fileSystem = new Mock<IFileSystem>();
                 fileSystem.Setup(x => x.DirectoryExists(binFolder)).Returns(true);
@@ -107,7 +107,7 @@ namespace ScriptCs.Tests
 
                 var resolver = new AssemblyResolver(fileSystem.Object, Mock.Of<IPackageAssemblyResolver>(), assemblyUtility.Object, Mock.Of<ILog>());
 
-                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory, "script.csx").ToList();
+                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory).ToList();
 
                 assemblies.Count.ShouldEqual(0);
             }
@@ -129,7 +129,7 @@ namespace ScriptCs.Tests
 
                 var resolver = new AssemblyResolver(fileSystem.Object, Mock.Of<IPackageAssemblyResolver>(), assemblyUtility.Object, Mock.Of<ILog>());
 
-                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory, null).ToList();
+                var assemblies = resolver.GetAssemblyPaths(WorkingDirectory).ToList();
 
                 assemblies.Count.ShouldEqual(1);
             }

--- a/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
@@ -31,7 +31,7 @@ namespace ScriptCs.Hosting.Tests
             public TheLoadMethod()
             {
                 var paths = new[] { "path1", "path2" };
-                _mockAssemblyResolver.Setup(r => r.GetAssemblyPaths(It.IsAny<string>(), It.IsAny<string>())).Returns(paths);
+                _mockAssemblyResolver.Setup(r => r.GetAssemblyPaths(It.IsAny<string>())).Returns(paths);
                 _modules.Add(
                     new Lazy<IModule, IModuleMetadata>(
                         () => _mockModule1.Object, new ModuleMetadata { Extensions = "ext1,ext2", Name = "module1" }));
@@ -47,7 +47,7 @@ namespace ScriptCs.Hosting.Tests
             {
                 var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (p, c) => { }, c => Enumerable.Empty<Lazy<IModule, IModuleMetadata>>());
                 loader.Load(null, "c:\test", null);
-                _mockAssemblyResolver.Verify(r => r.GetAssemblyPaths("c:\test", string.Empty));
+                _mockAssemblyResolver.Verify(r => r.GetAssemblyPaths("c:\test"));
             }
 
             [Fact]


### PR DESCRIPTION
Updated to use .scriptcs.build.dll as suffix for compiled assemblies
Avoid loading all previously compiled assemblies from bin folder.
