### PR TITLE
Fix #462 - Nicer error when a extensionless script name is passed

### DIFF
--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -27,9 +27,14 @@ namespace ScriptCs
 
             var modules = GetModuleList(commandArgs.Modules);
             var extension = Path.GetExtension(commandArgs.ScriptName);
-            if (extension != null)
+            if (!string.IsNullOrWhiteSpace(extension))
             {
                 extension = extension.Substring(1);
+            }
+            else if (extension == string.Empty)
+            {
+                console.WriteLine(string.Format("{0} is not a valid script name.", commandArgs.ScriptName));
+                return 1;
             }
 
             scriptServicesBuilder.LoadModules(extension, modules);


### PR DESCRIPTION
This is a preliminary fix for #462. This handles scriptcs being called with "scriptcs foo" with an error identifying foo as an invalid script name. This preserves the fall through at this stage when scriptcs is called with no arguments resulting in the REPL.
