### PR TITLE
In some cases Roslyn seems to emit 2 assemblies not 1 - take the last one

### DIFF
--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -37,7 +37,7 @@ namespace ScriptCs.Engine.Roslyn
 
             // the assembly is automatically loaded into the AppDomain when compiled
             // just need to find and return it
-            return AppDomain.CurrentDomain.GetAssemblies().FirstOrDefault(x => x.FullName.StartsWith(RoslynAssemblyNameCharacter));
+            return AppDomain.CurrentDomain.GetAssemblies().LastOrDefault(x => x.FullName.StartsWith(RoslynAssemblyNameCharacter));
         }
     }
 }


### PR DESCRIPTION
Right now we take the First Roslyn assembly, but we should take the last. Sometimes it emits two, and the first one is invalid  by the time second is emitted (as if it was a scripting session).

![2013-10-11_0440](https://f.cloud.github.com/assets/1710369/1311929/c637dbc6-3220-11e3-8953-1c66b71ca14a.png)

I'll check with Roslyn guys, but in the meantime this should fix #483.
