### PR TITLE
Fixes #499 - first part 

### DIFF
--- a/src/ScriptCs/Argument/ArgumentHandler.cs
+++ b/src/ScriptCs/Argument/ArgumentHandler.cs
@@ -1,9 +1,9 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-using PowerArgs;
+﻿using PowerArgs;
 using ScriptCs.Contracts;
 using ServiceStack.Text;
+using System;
+using System.Linq;
+using System.Reflection;
 
 namespace ScriptCs.Argument
 {
@@ -29,7 +29,7 @@ namespace ScriptCs.Argument
             var sr = SplitScriptArgs(args);
 
             var commandArgs = _argumentParser.Parse(sr.CommandArguments);
-            var configArgs = _configFileParser.Parse(GetFileContent(commandArgs.Config));
+            var configArgs = _configFileParser.Parse(GetFileContent(commandArgs != null ? commandArgs.Config : null));
             var finalArguments = ReconcileArguments(configArgs, commandArgs, sr);
 
             return new ArgumentParseResult(args, finalArguments, sr.ScriptArguments);
@@ -60,7 +60,7 @@ namespace ScriptCs.Argument
             result.ScriptArguments = new string[scriptArgsCount];
             Array.Copy(args, separatorLocation + 1, result.ScriptArguments, 0, scriptArgsCount);
 
-            if(separatorLocation != -1)
+            if (separatorLocation != -1)
                 result.CommandArguments = args.Take(separatorLocation).ToArray();
 
             return result;
@@ -80,15 +80,15 @@ namespace ScriptCs.Argument
                 var commandValue = property.GetValue(commandArgs);
                 var defaultValue = GetPropertyDefaultValue(property);
 
-                if(!object.Equals(configValue, commandValue))
+                if (!object.Equals(configValue, commandValue))
                 {
-                    if(!object.Equals(commandValue, defaultValue))
+                    if (!object.Equals(commandValue, defaultValue))
                     {
                         property.SetValue(configArgs, commandValue);
                     }
                     else
                     {
-                        if(IsCommandLinePresent(splitResult.CommandArguments, property))
+                        if (IsCommandLinePresent(splitResult.CommandArguments, property))
                             property.SetValue(configArgs, commandValue);
                     }
                 }
@@ -103,7 +103,7 @@ namespace ScriptCs.Argument
 
             var attribute = property.GetCustomAttribute<ArgShortcut>();
 
-            if(attribute != null)
+            if (attribute != null)
                 attributeFound = args.Any(a => a.Contains((attribute as ArgShortcut).Shortcut));
 
             var result = args.Any(a => a.Contains(property.Name)) || attributeFound;

--- a/test/ScriptCs.Tests/ArgumentHandlerTests.cs
+++ b/test/ScriptCs.Tests/ArgumentHandlerTests.cs
@@ -1,8 +1,8 @@
 ﻿using Moq;
 using ScriptCs.Argument;
 using ScriptCs.Contracts;
-using Xunit;
 using Should;
+using Xunit;
 
 namespace ScriptCs.Tests
 {
@@ -13,7 +13,7 @@ namespace ScriptCs.Tests
             private static IArgumentHandler Setup(string fileContent, string fileName = "scriptcs.opts", bool fileExists = true)
             {
                 const string currentDirectory = "C:\\test\\folder";
-                
+
                 string filePath = currentDirectory + '\\' + fileName;
 
                 var fs = new Mock<IFileSystem>();
@@ -73,6 +73,18 @@ namespace ScriptCs.Tests
                 result.CommandArguments.ScriptName.ShouldEqual("server.csx");
                 result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Error);
                 result.ScriptArguments.ShouldEqual(new string[] { "-port", "8080" });
+            }
+
+            [Fact]
+            public void ShouldHandleInvalidCommandLineArguments()
+            {
+                string[] args = { "-version", "-foo", "-bar" };
+
+                var argumentHandler = Setup(null, "test.txt", false);
+                var result = argumentHandler.Parse(args);
+
+                result.CommandArguments.ShouldBeNull();
+                result.Arguments.Length.ShouldEqual<int>(3);
             }
 
             [Fact]


### PR DESCRIPTION
This fixes [#499](scriptcs/scriptcs/issues/499)

The ArgumentParser Class would catch the ArgException and return null.
But the calling method in ArgumentHandler Class would then try to access
the returning null object.
