### PR TITLE
make IScriptHostFactory generic to allow custom script hosts

### DIFF
--- a/src/ScriptCs.Core/IScriptHostFactory.cs
+++ b/src/ScriptCs.Core/IScriptHostFactory.cs
@@ -2,8 +2,8 @@
 
 namespace ScriptCs
 {
-    public interface IScriptHostFactory
+    public interface IScriptHostFactory<TScriptHost>
     {
-        IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs);
+        TScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs);
     }
 }

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -2,7 +2,7 @@
 
 namespace ScriptCs
 {
-    public class ScriptHostFactory : IScriptHostFactory
+    public class ScriptHostFactory : IScriptHostFactory<IScriptHost>
     {
         public IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs)
         {

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
@@ -11,12 +11,12 @@ using ScriptCs.Exceptions;
 
 namespace ScriptCs.Engine.Roslyn
 {
-    public abstract class RoslynScriptCompilerEngine : RoslynScriptEngine
+    public abstract class RoslynScriptCompilerEngine<TScriptHost> : RoslynScriptEngine<TScriptHost> where TScriptHost : class
     {
         protected const string CompiledScriptClass = "Submission#0";
         protected const string CompiledScriptMethod = "<Factory>";
-        
-        protected RoslynScriptCompilerEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+
+        protected RoslynScriptCompilerEngine(IScriptHostFactory<TScriptHost> scriptHostFactory, ILog logger)
             : base(scriptHostFactory, logger)
         {
         }

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -11,13 +11,13 @@ namespace ScriptCs.Engine.Roslyn
 {
     using System.Runtime.ExceptionServices;
 
-    public class RoslynScriptEngine : IScriptEngine
+    public class RoslynScriptEngine<TScriptHost> : IScriptEngine where TScriptHost : class
     {
         protected readonly ScriptEngine ScriptEngine;
-        private readonly IScriptHostFactory _scriptHostFactory;
+        private readonly IScriptHostFactory<TScriptHost> _scriptHostFactory;
         public const string SessionKey = "Session";
 
-        public RoslynScriptEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+        public RoslynScriptEngine(IScriptHostFactory<TScriptHost> scriptHostFactory, ILog logger)
         {
             ScriptEngine = new ScriptEngine();
             ScriptEngine.AddReference(typeof(ScriptExecutor).Assembly);

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
@@ -4,9 +4,9 @@ using Common.Logging;
 
 namespace ScriptCs.Engine.Roslyn
 {
-    public class RoslynScriptInMemoryEngine : RoslynScriptCompilerEngine
+    public class RoslynScriptInMemoryEngine<TScriptHost> : RoslynScriptCompilerEngine<TScriptHost> where TScriptHost : class
     {
-        public RoslynScriptInMemoryEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+        public RoslynScriptInMemoryEngine(IScriptHostFactory<TScriptHost> scriptHostFactory, ILog logger)
             : base(scriptHostFactory, logger)
         {
         }

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -9,12 +9,12 @@ using ScriptCs.Contracts;
 
 namespace ScriptCs.Engine.Roslyn
 {
-    public class RoslynScriptPersistentEngine : RoslynScriptCompilerEngine
+    public class RoslynScriptPersistentEngine<TScriptHost> : RoslynScriptCompilerEngine<TScriptHost> where TScriptHost : class
     {
         private readonly IFileSystem _fileSystem;
         private const string RoslynAssemblyNameCharacter = "ℛ";
 
-        public RoslynScriptPersistentEngine(IScriptHostFactory scriptHostFactory, ILog logger, IFileSystem fileSystem)
+        public RoslynScriptPersistentEngine(IScriptHostFactory<TScriptHost> scriptHostFactory, ILog logger, IFileSystem fileSystem)
             : base(scriptHostFactory, logger)
         {
             _fileSystem = fileSystem;

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -52,7 +52,7 @@ namespace ScriptCs
             RegisterOverrideOrDefault<IPackageContainer>(builder, b => b.RegisterType<PackageContainer>().As<IPackageContainer>().SingleInstance());
             RegisterOverrideOrDefault<IPackageAssemblyResolver>(builder, b => b.RegisterType<PackageAssemblyResolver>().As<IPackageAssemblyResolver>().SingleInstance());
             RegisterOverrideOrDefault<IAssemblyResolver>(builder, b => b.RegisterType<AssemblyResolver>().As<IAssemblyResolver>().SingleInstance());
-            RegisterOverrideOrDefault<IScriptHostFactory>(builder, b => b.RegisterType<ScriptHostFactory>().As<IScriptHostFactory>().SingleInstance());
+            RegisterOverrideOrDefault<IScriptHostFactory<IScriptHost>>(builder, b => b.RegisterType<ScriptHostFactory>().As<IScriptHostFactory<IScriptHost>>().SingleInstance());
             RegisterOverrideOrDefault<IFilePreProcessor>(builder, b => b.RegisterType<FilePreProcessor>().As<IFilePreProcessor>().SingleInstance());
             RegisterOverrideOrDefault<IScriptPackResolver>(builder, b => b.RegisterType<ScriptPackResolver>().As<IScriptPackResolver>().SingleInstance());
             RegisterOverrideOrDefault<IInstallationProvider>(builder, b => b.RegisterType<NugetInstallationProvider>().As<IInstallationProvider>().SingleInstance());

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -36,9 +36,9 @@ namespace ScriptCs
         public ScriptServices Build()
         {
             var defaultExecutorType = typeof(ScriptExecutor);
-            Type defaultEngineType = _inMemory ? typeof(RoslynScriptInMemoryEngine) : typeof(RoslynScriptPersistentEngine);
+            Type defaultEngineType = _inMemory ? typeof(RoslynScriptInMemoryEngine<IScriptHost>) : typeof(RoslynScriptPersistentEngine<IScriptHost>);
 
-            defaultEngineType = _repl ? typeof(RoslynScriptEngine) : defaultEngineType;
+            defaultEngineType = _repl ? typeof(RoslynScriptEngine<IScriptHost>) : defaultEngineType;
 
             _scriptExecutorType = Overrides.ContainsKey(typeof(IScriptExecutor)) ? (Type)Overrides[typeof(IScriptExecutor)] : defaultExecutorType;
             _scriptEngineType = Overrides.ContainsKey(typeof(IScriptEngine)) ? (Type)Overrides[typeof(IScriptEngine)] : defaultEngineType;

--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptEngineTests.cs
@@ -20,7 +20,7 @@ namespace ScriptCs.Tests
             [Theory, ScriptCsAutoData]
             public void ShouldAddReferenceToCore()
             {
-                var engine = new RoslynTestScriptEngine(new Mock<IScriptHostFactory>().Object, new Mock<ILog>().Object);
+                var engine = new RoslynTestScriptEngine(new Mock<IScriptHostFactory<IScriptHost>>().Object, new Mock<ILog>().Object);
                 engine.Engine.GetReferences().Where(x => x.Display.EndsWith("ScriptCs.Core.dll")).Count().ShouldEqual(1);
             }
         }
@@ -29,10 +29,10 @@ namespace ScriptCs.Tests
         {
             [Theory, ScriptCsAutoData]
             public void ShouldCreateScriptHostWithContexts(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
                 [Frozen] Mock<IScriptPack> scriptPack,
                 ScriptPackSession scriptPackSession,
-                [NoAutoProperties] RoslynScriptEngine engine)
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine)
             {
                 // Arrange
                 const string Code = "var a = 0;";
@@ -52,7 +52,7 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldReuseExistingSessionIfProvided(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
                 [NoAutoProperties] RoslynTestScriptEngine engine,
                 ScriptPackSession scriptPackSession)
             {
@@ -63,7 +63,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 engine.Execute(Code, new string[0], Enumerable.Empty<string>(), Enumerable.Empty<string>(), scriptPackSession);
@@ -74,7 +74,7 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldCreateNewSessionIfNotProvided(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
                 [NoAutoProperties] RoslynTestScriptEngine engine,
                 ScriptPackSession scriptPackSession)
             {
@@ -93,7 +93,7 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldAddNewReferencesIfTheyAreProvided(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
                 [NoAutoProperties] RoslynTestScriptEngine engine,
                 ScriptPackSession scriptPackSession)
             {
@@ -104,18 +104,18 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
 
                 // Assert
-                ((SessionState<Session>)scriptPackSession.State[RoslynScriptEngine.SessionKey]).References.Count().ShouldEqual(1);
+                ((SessionState<Session>)scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey]).References.Count().ShouldEqual(1);
             }
 
             [Theory, ScriptCsAutoData]
             public void ShouldReturnAScriptResult(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
                 [NoAutoProperties] RoslynTestScriptEngine engine,
                 ScriptPackSession scriptPackSession)
             {
@@ -126,7 +126,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
@@ -137,8 +137,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldReturnCompileExceptionIfCodeDoesNotCompile(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -148,8 +148,8 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
+
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
 
@@ -159,8 +159,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldNotReturnCompileExceptionIfCodeDoesCompile(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -170,8 +170,8 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
+
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
 
@@ -181,8 +181,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldReturnExecuteExceptionIfCodeExecutionThrowsException(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -192,8 +192,8 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
+
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
 
@@ -203,8 +203,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldNotReturnExecuteExceptionIfCodeExecutionDoesNotThrowAnException(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -214,7 +214,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
@@ -225,8 +225,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldReturnReturnValueIfCodeExecutionReturnsValue(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 const string Code = "\"Hello\" //this should return \"Hello\"";
@@ -236,7 +236,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
@@ -247,8 +247,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldNotReturnReturnValueIfCodeExecutionDoesNotReturnValue(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -258,8 +258,8 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
-                
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
+
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
 
@@ -269,8 +269,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldSetIsPendingClosingCharToTrueIfCodeIsMissingCurlyBracket(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -280,7 +280,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(
@@ -293,8 +293,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldSetIsPendingClosingCharToTrueIfCodeIsMissingSquareBracket(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -304,7 +304,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
@@ -316,8 +316,8 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldSetIsPendingClosingCharToTrueIfCodeIsMissingParenthesis(
-                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
-                [NoAutoProperties] RoslynScriptEngine engine,
+                [Frozen] Mock<IScriptHostFactory<IScriptHost>> scriptHostFactory,
+                [NoAutoProperties] RoslynScriptEngine<IScriptHost> engine,
                 ScriptPackSession scriptPackSession)
             {
                 // Arrange
@@ -327,7 +327,7 @@ namespace ScriptCs.Tests
                     .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, q));
 
                 var session = new SessionState<Session> { Session = new ScriptEngine().CreateSession() };
-                scriptPackSession.State[RoslynScriptEngine.SessionKey] = session;
+                scriptPackSession.State[RoslynScriptEngine<IScriptHost>.SessionKey] = session;
 
                 // Act
                 var result = engine.Execute(Code, new string[0], new[] { "System" }, Enumerable.Empty<string>(), scriptPackSession);
@@ -338,9 +338,9 @@ namespace ScriptCs.Tests
             }
         }
 
-        public class RoslynTestScriptEngine : RoslynScriptEngine
+        public class RoslynTestScriptEngine : RoslynScriptEngine<IScriptHost>
         {
-            public RoslynTestScriptEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+            public RoslynTestScriptEngine(IScriptHostFactory<IScriptHost> scriptHostFactory, ILog logger)
                 : base(scriptHostFactory, logger)
             {
             }

--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptInMemoryEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptInMemoryEngineTests.cs
@@ -21,7 +21,7 @@ namespace ScriptCs.Tests
         {
             [Theory, ScriptCsAutoData]
             public void ShouldExposeExceptionThrownByScriptWhenErrorOccurs(
-                [NoAutoProperties] RoslynScriptInMemoryEngine scriptEngine)
+                [NoAutoProperties] RoslynScriptInMemoryEngine<IScriptHost> scriptEngine)
             {
                 // Arrange
                 var lines = new List<string>
@@ -45,7 +45,7 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void ShouldExposeExceptionThrownByCompilation(
-                [NoAutoProperties] RoslynScriptInMemoryEngine scriptEngine)
+                [NoAutoProperties] RoslynScriptInMemoryEngine<IScriptHost> scriptEngine)
             {
                 // Arrange
                 var lines = new List<string>

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -71,7 +71,7 @@ namespace ScriptCs.Tests
             [Fact]
             public void ShouldRegisterTheDefaultScriptHostFactoryIfNoOverride()
             {
-                _runtimeServices.Container.Resolve<IScriptHostFactory>().ShouldNotBeNull();
+                _runtimeServices.Container.Resolve<IScriptHostFactory<IScriptHost>>().ShouldNotBeNull();
             }
 
             [Fact]
@@ -137,9 +137,9 @@ namespace ScriptCs.Tests
             [Fact]
             public void ShouldRegisterTheOverriddenScriptHostFactory()
             {
-                var mock = new Mock<IScriptHostFactory>();
-                _overrides[typeof(IScriptHostFactory)] = mock.Object.GetType();
-                _runtimeServices.Container.Resolve<IScriptHostFactory>().ShouldBeType(mock.Object.GetType());
+                var mock = new Mock<IScriptHostFactory<IScriptHost>>();
+                _overrides[typeof(IScriptHostFactory<IScriptHost>)] = mock.Object.GetType();
+                _runtimeServices.Container.Resolve<IScriptHostFactory<IScriptHost>>().ShouldBeType(mock.Object.GetType());
             }
 
             [Fact]


### PR DESCRIPTION
speculative PR for discussion/feedback or even a merge! :wink:

So I finally worked out how to get my own methods and properties on my script host, as per the discussion at https://github.com/scriptcs/scriptcs/issues/315#issuecomment-19854517

It occurred to me that the properties/methods I was adding to my own host derived from `IScriptHost` were not available to scripts because `RoslynScriptEngine` is always calling `Roslyn.Scripting.CommonScriptEngine.CreateSession<THostObject>()` with an `IScriptHost` object, so Roslyn was only surfacing the members defined on `IScriptHost` to scripts.

Now, perhaps I'm missing something obvious and someone can shame me here with a much simpler solution, but I found that by writing my own script engine based on `RoslynScriptEngine` but using my own script host interface fixed things for me - https://github.com/config-r/config-r/blob/dev/src/ConfigR/Scripting/ConfigRScriptEngine.cs. This has a lot of duplicated code from `RoslynScriptEngine` and its only effective purpose is to use a different type parameter when calling `CreateSession<THostObject>()`.

If `IScriptHostFactory` becomes generic, then I can just reuse `RoslynScriptEngine` and rip all that duplication out of ConfigR.

I believe the ability to define custom hosts is essential for scriptcs to be used as a hosting solution in anger so I'm keen to get this in.

Or of course if I'm being dumb then it would be great if someone could point out the easy way :innocent:.
