### PR TITLE
Remove 'blank to exit' from REPL (#509)

### DIFF
--- a/src/ScriptCs/Command/ExecuteReplCommand.cs
+++ b/src/ScriptCs/Command/ExecuteReplCommand.cs
@@ -82,7 +82,17 @@ namespace ScriptCs.Command
                 _console.Write("> ");
             }
 
-            var line = _console.ReadLine();
+            string line = null;
+            
+            try
+            {
+                line = _console.ReadLine();
+            }
+            catch
+            {
+                return false;
+            }
+
             if (!string.IsNullOrWhiteSpace(line))
             {
                 repl.Execute(line);

--- a/test/ScriptCs.Tests/ExecuteReplCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteReplCommandTests.cs
@@ -11,6 +11,7 @@ using ScriptCs.Contracts;
 using Should;
 
 using Xunit.Extensions;
+using System;
 
 namespace ScriptCs.Tests
 {
@@ -31,7 +32,7 @@ namespace ScriptCs.Tests
 
                 fileSystem.SetupGet(x => x.CurrentDirectory).Returns("C:\\");
 
-                console.Setup(x => x.ReadLine()).Returns(() => string.Empty).Callback(() => readLines++);
+                console.Setup(x => x.ReadLine()).Callback(() => readLines++).Throws(new Exception());
                 console.Setup(x => x.Write(It.IsAny<string>())).Callback<string>(value => builder.Append(value));
 
                 // Act
@@ -44,13 +45,17 @@ namespace ScriptCs.Tests
 
             [Theory, ScriptCsAutoData]
             public void WhenPassedAScript_ShouldPressedReplWithScript(
-                [Frozen] Mock<IScriptEngine> scriptEngine, [Frozen] Mock<IFileSystem> fileSystem,[Frozen] Mock<IConsole> console,
-                CommandFactory factory)
+                [Frozen] Mock<IScriptEngine> scriptEngine, [Frozen] Mock<IFileSystem> fileSystem, [Frozen] Mock<IConsole> console,
+                 CommandFactory factory)
             {
                 // Arrange
-                var args = new ScriptCsArgs { Repl = true, ScriptName = "test.csx"};
+                var args = new ScriptCsArgs { Repl = true, ScriptName = "test.csx" };
 
-                console.Setup(x => x.ReadLine()).Returns(() => string.Empty);
+                console.Setup(x => x.ReadLine()).Returns(() =>
+                {
+                    console.Setup(x => x.ReadLine()).Throws(new Exception());
+                    return string.Empty;
+                });
                 fileSystem.SetupGet(x => x.CurrentDirectory).Returns("C:\\");
                 scriptEngine.Setup(
                     x => x.Execute("#load test.csx", It.IsAny<string[]>(), It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<string>>(), It.IsAny<ScriptPackSession>()));
@@ -70,7 +75,11 @@ namespace ScriptCs.Tests
                 // Arrange
                 var args = new ScriptCsArgs { Repl = true };
 
-                console.Setup(x => x.ReadLine()).Returns(() => string.Empty);
+                console.Setup(x => x.ReadLine()).Returns(() =>
+                {
+                    console.Setup(x => x.ReadLine()).Throws(new Exception());
+                    return string.Empty;
+                });
                 fileSystem.SetupGet(x => x.CurrentDirectory).Returns("C:\\");
 
                 // Act


### PR DESCRIPTION
I've updated the ExecuteReplCommand to execute commands only if there is text to execute.

Currently only ctrl-c closes the REPL, if [ctrl-c x 2](https://github.com/scriptcs/scriptcs/issues/509#issuecomment-28203425) has to be implemented I can look into it.
