### PR TITLE
Enable multicore JIT for scriptcs.exe

### DIFF
--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Runtime;
 using ScriptCs.Argument;
 using ScriptCs.Command;
 
@@ -6,8 +7,11 @@ namespace ScriptCs
 {
     internal static class Program
     {
-        private static int Main(string[] args) 
+        private static int Main(string[] args)
         {
+            ProfileOptimization.SetProfileRoot(typeof(Program).Assembly.Location);
+            ProfileOptimization.StartProfile(typeof(Program).Assembly.GetName().Name + ".profile");
+
             var console = new ScriptConsole();
 
             var parser = new ArgumentHandler(new ArgumentParser(console), new ConfigFileParser(console), new FileSystem());


### PR DESCRIPTION
This enables the [multicore JIT](http://blogs.msdn.com/b/dotnet/archive/2012/10/18/an-easy-solution-for-improving-app-launch-performance.aspx) feature that was introduced in .NET 4.5 for `scriptcs.exe` in an effort to improve startup times.
