### PR TITLE
Use chocolatey install path conventions

### DIFF
--- a/src/ScriptCs/Properties/chocolateyInstall.ps1
+++ b/src/ScriptCs/Properties/chocolateyInstall.ps1
@@ -1,7 +1,7 @@
 ﻿try { 
     $tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
     $nuget = "$env:ChocolateyInstall\ChocolateyInstall\nuget"
-    $binPath = "$env:APPDATA\scriptcs"
+    $binPath = "$env:chocolatey_bin_root\scriptcs"
     $nugetPath = "$tools\nugets"
 
     New-Item $binPath -ItemType Directory -Force | Out-Null

--- a/src/ScriptCs/Properties/chocolateyUninstall.ps1
+++ b/src/ScriptCs/Properties/chocolateyUninstall.ps1
@@ -1,5 +1,6 @@
 ﻿try {
     $paths = @(
+        "$env:chocolatey_bin_root\scriptcs",
         "$env:APPDATA\scriptcs",
         "$env:LOCALAPPDATA\scriptcs"
     )


### PR DESCRIPTION
Use the `chocolatey_bin_root` instead of `APPDATA` as `APPDATA` is
frequently locked down due to GroupPolicy conventions on what scripts
can be executed from here.
