### PR TITLE
Corrected behaviour for local NuGet.config

### DIFF
--- a/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
+++ b/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
@@ -42,9 +42,10 @@ namespace ScriptCs.Hosting.Package
             var configFileSystem = new PhysicalFileSystem(path);
 
             ISettings settings;
-            if (_fileSystem.FileExists(Path.Combine(_fileSystem.CurrentDirectory, Constants.NugetFile)))
+            var localNuGetConfigFile = Path.Combine(_fileSystem.CurrentDirectory, Constants.NugetFile);
+            if (_fileSystem.FileExists(localNuGetConfigFile))
             {
-                settings = new Settings(configFileSystem, Constants.NugetFile);
+                settings = Settings.LoadDefaultSettings(configFileSystem, localNuGetConfigFile, null);
             }
             else
             {


### PR DESCRIPTION
According to [Package installation](https://github.com/scriptcs/scriptcs/wiki/Package-installation) on the scriptcs wiki, if there is a local NuGet.config file present in the script or packages folder, then this file will be used by scriptcs for NuGet configuration.

This is not the behaviour I am seeing in the 0.9.0 release or the dev branch.

Firstly it looks like the `GetRepositorySources` method  in `ScriptCs.Hosting.Package.NugetInstallationProvider` only looks for NuGet.config in the **script** folder and not in the packages folder. This is easy enough to update in the wiki documentation - this feels like the correct behaviour.

The next issue is that the if statement in the following section of code in the `GetRepositorySources` method **creates** a NuGet.config file in the **packages** folder instead of **reading** the NuGet.config file placed in the script folder.

``` csharp
public IEnumerable<string> GetRepositorySources(string path)
{
  var configFileSystem = new PhysicalFileSystem(path);

  ISettings settings;
  if (_fileSystem.FileExists(Path.Combine(_fileSystem.CurrentDirectory, Constants.NugetFile)))
  {
    settings = new Settings(configFileSystem, Constants.NugetFile);
  }
  else
  {
    settings = Settings.LoadDefaultSettings(configFileSystem, null, new NugetMachineWideSettings());
  }
...
}
```

I have updated this code as follows and am now observing the behaviour as described in the wiki.

``` csharp
public IEnumerable<string> GetRepositorySources(string path)
{
  var configFileSystem = new PhysicalFileSystem(path);

  ISettings settings;
  var localNuGetConfigFile = Path.Combine(_fileSystem.CurrentDirectory, Constants.NugetFile);
  if (_fileSystem.FileExists(localNuGetConfigFile))
  {
    settings = Settings.LoadDefaultSettings(configFileSystem, localNuGetConfigFile, null);
  }
  else
  {
    settings = Settings.LoadDefaultSettings(configFileSystem, null, new NugetMachineWideSettings());
  }
...
}
```
