### PR TITLE
Repl change and view directory

### DIFF
--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -67,6 +67,17 @@ namespace ScriptCs
                     return new ScriptResult();
                 }
 
+                if (script.StartsWith(":cwd", StringComparison.OrdinalIgnoreCase))
+                {
+                    var dir = FileSystem.CurrentDirectory;
+
+                    Console.ForegroundColor = ConsoleColor.Yellow;
+
+                    Console.WriteLine(dir);
+
+                    return new ScriptResult();
+                }
+
                 var preProcessResult = FilePreProcessor.ProcessScript(script);
 
                 ImportNamespaces(preProcessResult.Namespaces.ToArray());


### PR DESCRIPTION
This PR is broken out from PR #590 (Word completion in REPL). This was requested by @glennblock.

Two new REPL commands are added:

:cd to change directory
:cwd to print current working directory.
