### PR TITLE
switch scriptcs.exe from SS to JSON.NET

### DIFF
--- a/src/ScriptCs/Argument/ArgumentHandler.cs
+++ b/src/ScriptCs/Argument/ArgumentHandler.cs
@@ -1,6 +1,5 @@
 ﻿using PowerArgs;
 using ScriptCs.Contracts;
-using ServiceStack.Text;
 using System;
 using System.Linq;
 using System.Reflection;
@@ -116,7 +115,7 @@ namespace ScriptCs.Argument
 
             return defaultAttribute != null
                        ? ((PowerArgs.DefaultValueAttribute)defaultAttribute).Value
-                       : property.PropertyType.GetDefaultValue();
+                       : property.PropertyType.IsValueType ? Activator.CreateInstance(property.PropertyType) : null;
         }
 
         public class SplitResult

--- a/src/ScriptCs/Argument/ConfigFileParser.cs
+++ b/src/ScriptCs/Argument/ConfigFileParser.cs
@@ -3,9 +3,9 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
+using Newtonsoft.Json;
 using PowerArgs;
 using ScriptCs.Contracts;
-using ServiceStack.Text;
 
 namespace ScriptCs.Argument
 {
@@ -80,7 +80,7 @@ namespace ScriptCs.Argument
 
             try
             {
-                dict = JsonSerializer.DeserializeFromString<Dictionary<string, string>>(content);
+                dict = JsonConvert.DeserializeObject<Dictionary<string, string>>(content);
             }
             catch 
             {

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -33,13 +33,13 @@
     <Reference Include="Common.Logging">
       <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="PowerArgs, Version=1.6.0.0, Culture=neutral, PublicKeyToken=54832990a0812961, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\PowerArgs.1.6.0.0\lib\net40\PowerArgs.dll</HintPath>
-    </Reference>
-    <Reference Include="ServiceStack.Text, Version=3.9.45.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\ServiceStack.Text.3.9.47\lib\net35\ServiceStack.Text.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/ScriptCs/packages.config
+++ b/src/ScriptCs/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="Autofac" version="3.3.0" targetFramework="net45" />
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.1" targetFramework="net45" />
   <package id="PowerArgs" version="1.6.0.0" targetFramework="net45" />
-  <package id="ServiceStack.Text" version="3.9.47" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hosting already depends on JSON.NET so this reduces the number of dependencies by one since ServiceStack is no longer used anywhere.
