### PR TITLE
Fix for issue #605 - Unit Tests are failing due to localisation

### DIFF
--- a/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptInMemoryEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/RoslynScriptInMemoryEngineTests.cs
@@ -40,7 +40,7 @@ namespace ScriptCs.Tests
 
                 // Assert
                 var exception = Assert.Throws<InvalidOperationException>(() => result.ExecuteExceptionInfo.Throw());
-                exception.StackTrace.ShouldContain("at Submission#0");
+                exception.StackTrace.ShouldContain("Submission#0");
                 exception.Message.ShouldContain("InvalidOperationExceptionMessage");
             }
 

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -236,7 +236,7 @@ namespace ScriptCs.Hosting.Tests
                 var initializationServices = new InitializationServices(_mockLogger.Object, _overrides);
                 var runtimeServices = new RuntimeServices(_mockLogger.Object, _overrides, new List<Type>(), _mockConsole.Object, _scriptEngineType, _scriptExecutorType, true, initializationServices, "script.csx");
                 var container = runtimeServices.Container;
-                _mockLogger.Verify(l=>l.DebugFormat("Failure loading assembly: {0}. Exception: {1}", "foo.dll", "Could not load file or assembly 'foo.dll' or one of its dependencies. The system cannot find the file specified."));
+                _mockLogger.Verify(l => l.DebugFormat("Failure loading assembly: {0}. Exception: {1}", "foo.dll", It.IsAny<string>()));
             }
 
             [Fact]


### PR DESCRIPTION
This commit contains minor fixes to unit tests that fail due to differences in locales. The changes make the failing unit tests agnostic to locales.
