### PR TITLE
Print loader exceptions in case AggregateCatalog would throw

### DIFF
--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel.Composition.Hosting;
 using System.Linq;
+using System.Reflection;
 using Autofac;
 using Autofac.Integration.Mef;
 using Common.Logging;
@@ -77,6 +78,18 @@ namespace ScriptCs.Hosting
                         catalog.Parts.ToList(); //force the Parts to be read
                         aggregateCatalog.Catalogs.Add(catalog);
                     }
+                    catch (ReflectionTypeLoadException typeLoadEx)
+                    {
+                        assemblyLoadFailures = true;
+                        if (typeLoadEx.LoaderExceptions != null && typeLoadEx.LoaderExceptions.Any())
+                        {
+                            foreach (var ex in typeLoadEx.LoaderExceptions.GroupBy(x => x.Message))
+                            {
+                                Logger.DebugFormat("Failure loading assembly: {0}. Exception: {1}", assembly,
+                                    ex.First().Message);
+                            }
+                        }
+                    }
                     catch(Exception ex)
                     {
                         assemblyLoadFailures = true;
@@ -85,10 +98,9 @@ namespace ScriptCs.Hosting
                 }
                 if (assemblyLoadFailures)
                 {
-                    if (_scriptName == null || _scriptName.Length == 0)
-                        Logger.Warn("Some assemblies failed to load. Launch with '-repl -loglevel debug' to see the details");
-                    else    
-                        Logger.Warn("Some assemblies failed to load. Launch with '-loglevel debug' to see the details");
+                    Logger.Warn(string.IsNullOrEmpty(_scriptName)
+                        ? "Some assemblies failed to load. Launch with '-repl -loglevel debug' to see the details"
+                        : "Some assemblies failed to load. Launch with '-loglevel debug' to see the details");
                 }
                 builder.RegisterComposablePartCatalog(aggregateCatalog);
             }


### PR DESCRIPTION
Right now, if AggregateCatalog responsible for finding script packs throws, we would not show which assembly is missing. We can catch `ReflectionTypeLoadException` to remedy that - with this change, we get to display the failure DLL info correctly, for example:

![image](https://cloud.githubusercontent.com/assets/1710369/2561694/854b7d54-b824-11e3-92ac-e2762a24342d.png)
