### PR TITLE
Naive fix for PCL targetFramework selection

### DIFF
--- a/src/ScriptCs.Hosting/Package/PackageContainer.cs
+++ b/src/ScriptCs.Hosting/Package/PackageContainer.cs
@@ -4,17 +4,16 @@ using System.Linq;
 using System.Runtime.Versioning;
 using Common.Logging;
 using NuGet;
-
 using ScriptCs.Contracts;
-
 using IFileSystem = ScriptCs.Contracts.IFileSystem;
-using PackageReference = ScriptCs.PackageReference;
 
 namespace ScriptCs.Hosting.Package
 {
     public class PackageContainer : IPackageContainer
     {
         private const string DotNetFramework = ".NETFramework";
+
+        private const string DotNetPortable = ".NETPortable";
 
         private readonly IFileSystem _fileSystem;
 
@@ -134,9 +133,21 @@ namespace ScriptCs.Hosting.Package
         private static FrameworkName GetNewestSupportedFramework(IPackage packageMetadata)
         {
             return packageMetadata.GetSupportedFrameworks()
-                .Where(x => x.Identifier == DotNetFramework)
+                .Where(IsValidFramework)
                 .OrderByDescending(x => x.Version)
                 .FirstOrDefault();
+        }
+
+        private static bool IsValidFramework(FrameworkName frameworkName)
+        {
+            return frameworkName.Identifier == DotNetFramework
+                || (frameworkName.Identifier == DotNetPortable 
+                    && frameworkName.Profile.Split('+').Any(IsValidProfile));
+        }
+
+        private static bool IsValidProfile(string profile)
+        {
+            return profile == "net40" || profile == "net45";
         }
     }
 }


### PR DESCRIPTION
Fixes #511

Before:
![2014-04-01_09-43-36](https://cloud.githubusercontent.com/assets/582487/2576633/aca484a6-b971-11e3-8170-22e91de70893.png)

After:
![2014-04-01_09-32-13](https://cloud.githubusercontent.com/assets/582487/2576636/b34f4bec-b971-11e3-807c-fa58bf00858d.png)

This might be a bit naive, but it works:

![2014-04-01_09-58-43](https://cloud.githubusercontent.com/assets/582487/2576699/486dc996-b973-11e3-9d8e-f99b354af9d4.png)

:grin::+1:
