### PR TITLE
Fix for #501 - Configuration ignored

### DIFF
--- a/src/ScriptCs/Argument/ArgumentHandler.cs
+++ b/src/ScriptCs/Argument/ArgumentHandler.cs
@@ -103,9 +103,9 @@ namespace ScriptCs.Argument
             var attribute = property.GetCustomAttribute<ArgShortcut>();
 
             if (attribute != null)
-                attributeFound = args.Any(a => a.Contains((attribute as ArgShortcut).Shortcut));
+                attributeFound = args.Any(a => a.Contains("-" + (attribute as ArgShortcut).Shortcut));
 
-            var result = args.Any(a => a.Contains(property.Name)) || attributeFound;
+            var result = args.Any(a => a.Contains("-" + property.Name)) || attributeFound;
             return result;
         }
 

--- a/test/ScriptCs.Tests/ArgumentHandlerTests.cs
+++ b/test/ScriptCs.Tests/ArgumentHandlerTests.cs
@@ -137,6 +137,22 @@ namespace ScriptCs.Tests
             }
 
             [Fact]
+            public void ShouldHandleScriptNameStartingWithRepl()
+            {
+                const string file = "{\"repl\": true}";
+                string[] args = { "replication.csx", "--", "-port", "8080" };
+
+                var argumentHandler = Setup(file);
+                var result = argumentHandler.Parse(args);
+
+                result.ShouldNotBeNull();
+                result.Arguments.ShouldEqual(args);
+                result.CommandArguments.ScriptName.ShouldEqual("replication.csx");
+                result.CommandArguments.Repl.ShouldBeTrue();
+                result.ScriptArguments.ShouldEqual(new string[] { "-port", "8080" });
+            }
+
+            [Fact]
             public void ShouldUseScriptOptsIfParsingFailed()
             {
                 var parser = new Mock<IArgumentParser>();


### PR DESCRIPTION
This fixes the problem exhibited in issue #501 were configuration settings were not taking effect when an argument contained the parameter.

For example: Having a script name of myInstall.csx could override the Install option in the configuration.

Prefixing the Contains search should resolve this. All tests pass.
