### PR TITLE
Log full exception from script execution

### DIFF
--- a/src/ScriptCs/Command/ExecuteScriptCommand.cs
+++ b/src/ScriptCs/Command/ExecuteScriptCommand.cs
@@ -80,7 +80,7 @@ namespace ScriptCs.Command
             }
             catch (Exception ex)
             {
-                _logger.Error(ex.Message);
+                _logger.Error(ex);
                 return CommandResult.Error;
             }
         }


### PR DESCRIPTION
Whilst developing Bau as a script pack, I was getting a cryptic error from scriptcs:

> ERROR: The type initializer for 'Bau.ExecuteTasks' threw an exception.

The only way I could find out what the problem was, was to debug scriptcs from Visual Studio. The problem stems from the fact that we are only logging the exception message, rather than the exception object, so the details are lost. By changing the logging call to pass the exception rather than the message, I can immediately see what the problem is.

There are other instances in the scriptcs source where we are logging only the message and not the exception. They may be worth reviewing as well.

before
![image](https://cloud.githubusercontent.com/assets/677704/2812095/5bde3898-ce41-11e3-9b57-1f310c424012.png)
after
![image](https://cloud.githubusercontent.com/assets/677704/2812097/625eb17a-ce41-11e3-95a8-2091b47735f3.png)
