### PR TITLE
#669 fixed ExecuteReplCommand.ScriptArgs to use backing field

### DIFF
--- a/src/ScriptCs/Command/ExecuteReplCommand.cs
+++ b/src/ScriptCs/Command/ExecuteReplCommand.cs
@@ -42,7 +42,10 @@ namespace ScriptCs.Command
             _assemblyResolver = assemblyResolver;
         }
 
-        public string[] ScriptArgs { get; private set; }
+        public string[] ScriptArgs
+        {
+            get { return _scriptArgs; }
+        }
 
         public CommandResult Execute()
         {
@@ -87,7 +90,7 @@ namespace ScriptCs.Command
             }
 
             string line = null;
-            
+
             try
             {
                 line = _console.ReadLine();


### PR DESCRIPTION
fixes #669
