### PR TITLE
Added exception handling mono setting profileroot

### DIFF
--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -5,6 +5,7 @@ using ScriptCs.Argument;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
+using System.Runtime.CompilerServices;
 
 namespace ScriptCs
 {
@@ -13,13 +14,15 @@ namespace ScriptCs
         private static int Main(string[] args)
         {
 #if !MONO
-            if (Type.GetType("Mono.Runtime") == null)
+            try
             {
-                ProfileOptimization.SetProfileRoot(typeof(Program).Assembly.Location);
-                ProfileOptimization.StartProfile(typeof(Program).Assembly.GetName().Name + ".profile");
+                SetProfile();
             }
-
+            catch (TypeLoadException)
+            {
+            }
 #endif
+
             IConsole console = new ScriptConsole();
 
             var parser = new ArgumentHandler(new ArgumentParser(console), new ConfigFileParser(console), new FileSystem());
@@ -88,6 +91,16 @@ namespace ScriptCs
             }
 
             return modules;
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static void SetProfile()
+        {
+            if (Type.GetType("Mono.Runtime") == null)
+            {
+                ProfileOptimization.SetProfileRoot(typeof(Program).Assembly.Location);
+                ProfileOptimization.StartProfile(typeof(Program).Assembly.GetName().Name + ".profile");
+            }
         }
     }
 }


### PR DESCRIPTION
Added exception handling for running on mono.

A simple try catch could not work as you can't catch a missing method exception as it occurs at the JIT level however you can move the method calls out to a new method and then catch the call to the new method.

This addresses #668 and have tested it on OSX Mavericks:

![screen shot 2014-05-10 at 21 01 41](https://cloud.githubusercontent.com/assets/105126/2936985/0081f9de-d87e-11e3-8381-a3456d54d714.png)

Not sure how the logging to the console about the exception is happening though :worried: 

Hope this helps!
