### PR TITLE
add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,6 @@
+Filip W <wojcieszyn@gmail.com> <wojcieszyn@gmail.com>
+Kristian Hellang <kristian@hellang.com> <khellang@hotmail.com>
+Justin Rusbatch <jrusbatch@gmail.com> <jrusbatch@users.noreply.github.com>
+dschenkelman <damian.schenkelman@gmail.com> <damian.schenkelman@gmail.com>
+Nick Berardi <nick@managedfusion.com> <nberardi@gmail.com>
+estoy <erik.stoy@bigfoot.com> <erik.stoy@tretton37.com>


### PR DESCRIPTION
Some people have committed with multiple settings for `user.name` and/or `user.email`.

`.mailmap` allows `git shortlog` to collapse entries.

E.g. `git shortlog -sne`

Before:
![image](https://cloud.githubusercontent.com/assets/677704/2941261/952e0d5e-d99e-11e3-9b1b-3c4be7907e7e.png)
After:
![image](https://cloud.githubusercontent.com/assets/677704/2941264/9fb47ab0-d99e-11e3-999b-21eb5d2f0d96.png)
