### PR TITLE
CRITICAL: Update AssemblyInfo and NuGet packages

### DIFF
--- a/common/CommonAssemblyInfo.cs
+++ b/common/CommonAssemblyInfo.cs
@@ -9,6 +9,7 @@ using System.Runtime.InteropServices;
 #endif
 
 [assembly: AssemblyProduct("scriptcs")]
+[assembly: AssemblyCompany("Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph")]
 [assembly: AssemblyCopyright("Copyright 2013 Glenn Block, Justin Rusbatch, Filip Wojcieszyn")]
 
 [assembly: ComVisible(false)]

--- a/src/ScriptCs.Contracts/Properties/ScriptCs.Contracts.nuspec
+++ b/src/ScriptCs.Contracts/Properties/ScriptCs.Contracts.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ScriptCs.Contracts</id>
     <version>$version$</version>
-    <authors>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</authors>
+    <authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph</authors>
     <owners>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</owners>
     <licenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://scriptcs.net</projectUrl>

--- a/src/ScriptCs.Core/Properties/ScriptCs.Core.nuspec
+++ b/src/ScriptCs.Core/Properties/ScriptCs.Core.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ScriptCs.Core</id>
     <version>$version$</version>
-    <authors>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</authors>
+    <authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph</authors>
     <owners>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</owners>
     <licenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://scriptcs.net</projectUrl>

--- a/src/ScriptCs.Engine.Roslyn/Properties/ScriptCs.Engine.Roslyn.nuspec
+++ b/src/ScriptCs.Engine.Roslyn/Properties/ScriptCs.Engine.Roslyn.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ScriptCs.Engine.Roslyn</id>
     <version>$version$</version>
-    <authors>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</authors>
+    <authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph</authors>
     <owners>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</owners>
     <licenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://scriptcs.net</projectUrl>

--- a/src/ScriptCs.Hosting/Properties/ScriptCs.Hosting.nuspec
+++ b/src/ScriptCs.Hosting/Properties/ScriptCs.Hosting.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>ScriptCs.Hosting</id>
     <version>$version$</version>
-    <authors>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</authors>
+    <authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph</authors>
     <owners>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</owners>
     <licenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://scriptcs.net</projectUrl>

--- a/src/ScriptCs/Properties/scriptcs.nuspec
+++ b/src/ScriptCs/Properties/scriptcs.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>scriptcs</id>
     <version>$version$</version>
-    <authors>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</authors>
+    <authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch, Kristian Hellang, Damian Schenkelman, Adam Ralph</authors>
     <owners>Glenn Block, Justin Rusbatch, Filip Wojcieszyn</owners>
     <licenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</licenseUrl>
     <projectUrl>http://scriptcs.net</projectUrl>


### PR DESCRIPTION
This fixes a critical bug that resulted in core contributors not being recognized appropriately for their efforts in helping to keep this project moving forward.
