### PR TITLE
Removed INFO prefix and added colour to console

### DIFF
--- a/src/ScriptCs.Hosting/ScriptConsoleLogger.cs
+++ b/src/ScriptCs.Hosting/ScriptConsoleLogger.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Common.Logging;
 using Common.Logging.Factory;
 using ScriptCs.Contracts;
@@ -11,6 +12,16 @@ namespace ScriptCs.Hosting
         private readonly LogLevel _consoleLogLevel;
         private readonly IConsole _console;
         private readonly ILog _log;
+        private readonly Dictionary<Common.Logging.LogLevel, ConsoleColor> colors =
+            new Dictionary<Common.Logging.LogLevel, ConsoleColor>
+            {
+                { Common.Logging.LogLevel.Fatal, ConsoleColor.Red },
+                { Common.Logging.LogLevel.Error, ConsoleColor.DarkRed },
+                { Common.Logging.LogLevel.Warn, ConsoleColor.DarkYellow },
+                { Common.Logging.LogLevel.Info, ConsoleColor.Gray },
+                { Common.Logging.LogLevel.Debug, ConsoleColor.DarkGray },
+                { Common.Logging.LogLevel.Trace, ConsoleColor.DarkMagenta },
+            };
 
         public ScriptConsoleLogger(LogLevel consoleLogLevel, IConsole console, ILog log)
         {
@@ -111,7 +122,26 @@ namespace ScriptCs.Hosting
 
             if (consoleLog)
             {
-                _console.WriteLine(string.Concat(level.ToString().ToUpperInvariant(), ": ", message.ToString()));
+                var prefix = level == Common.Logging.LogLevel.Info
+                    ? null
+                    : string.Concat(level.ToString().ToUpperInvariant(), ": ");
+
+                ConsoleColor color;
+                if (!colors.TryGetValue(level, out color))
+                {
+                    color = ConsoleColor.White;
+                }
+
+                var originalColor = _console.ForegroundColor;
+                _console.ForegroundColor = color;
+                try
+                {
+                    _console.WriteLine(string.Concat(prefix, message.ToString()));
+                }
+                finally
+                {
+                    _console.ForegroundColor = originalColor;
+                }
             }
         }
     }


### PR DESCRIPTION
For the colour, I went with subtle tones, following the lead of gulp and Bau:

FATAL: red
ERROR: dark red
WARN: dark yellow
INFO: gray
DEBUG: dark gray
TRACE: dark magenta

One advantage of these is that they work better on both black and white console backgrounds since they are closer to the middle of the palette.

If we don't mind more vibrant colours we could go with:

FATAL: yellow on red background (or vice versa)
ERROR: red
WARN: yellow
INFO: cyan
DEBUG: green
TRACE: gray

These are the default colours used by the coloured console logger in NLog (with the exception of FATAL).

Or some other scheme?

Any opinions?

INFO:
![image](https://cloud.githubusercontent.com/assets/677704/3007868/dd1c81a0-dea2-11e3-8503-b9b85321350a.png)

DEBUG:
![image](https://cloud.githubusercontent.com/assets/677704/3007874/0b699f02-dea3-11e3-8bc8-e8454d584f3a.png)

ERROR:
![image](https://cloud.githubusercontent.com/assets/677704/3007876/2748c234-dea3-11e3-886a-0fb21dab3923.png)
