### PR TITLE
#428 refactor: grab stderr for Linux

### DIFF
--- a/test/ScriptCs.Tests.Acceptance/Support/ProcessStartInfoExtensions.cs
+++ b/test/ScriptCs.Tests.Acceptance/Support/ProcessStartInfoExtensions.cs
@@ -18,6 +18,7 @@
                 process.ErrorDataReceived += (sender, e) => output.AppendLine(e.Data);
                 process.Start();
                 process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
                 process.WaitForExit();
 
                 using (var writer = new StreamWriter(logfile, true))


### PR DESCRIPTION
This didn't matter on Windows since over there all errors seem to go through `stdout` :unamused: but on Linux things behave as you might expect with errors going to `stderr`.

(I've now realised that this is what threw me when I was initially trying to get things working and I thought that `stdout` capture with `System.Diagnostics.Process` was broken on Linux!)
#428
