### PR TITLE
DirectiveLineProcessor.GetDirectiveArgument should trim all whitespace

### DIFF
--- a/src/ScriptCs.Contracts/DirectiveLineProcessor.cs
+++ b/src/ScriptCs.Contracts/DirectiveLineProcessor.cs
@@ -48,7 +48,7 @@ namespace ScriptCs.Contracts
             Guard.AgainstNullArgument("line", line);
 
             return line.Replace(DirectiveString, string.Empty)
-                .Trim(' ')
+                .Trim()
                 .Replace("\"", string.Empty)
                 .Replace(";", string.Empty);
         }


### PR DESCRIPTION
I forgot to make this requested change as part of my last set of commits.
