### PR TITLE
Remove console noise from Mono engine when platform is Mono

### DIFF
--- a/src/ScriptCs.Engine.Mono/MonoModule.cs
+++ b/src/ScriptCs.Engine.Mono/MonoModule.cs
@@ -1,19 +1,18 @@
-﻿using System;
-using ScriptCs.Contracts;
+﻿using ScriptCs.Contracts;
 
 namespace ScriptCs.Engine.Mono
 {
-    [Module(ModuleName)]
+    [Module("mono")]
     public class MonoModule : IModule
     {
-        public const string ModuleName = "mono";
-
         public void Initialize(IModuleConfiguration config)
         {
             Guard.AgainstNullArgument("config", config);
 
             if (!config.Overrides.ContainsKey(typeof(IScriptEngine)))
+            {
                 config.ScriptEngine<MonoScriptEngine>();
+            }
         }
     }
 }

--- a/src/ScriptCs.Engine.Roslyn/RoslynModule.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynModule.cs
@@ -2,11 +2,9 @@
 
 namespace ScriptCs.Engine.Roslyn
 {
-    [Module(ModuleName)]
+    [Module("roslyn")]
     public class RoslynModule : IModule
     {
-        public const string ModuleName = "roslyn";
-
         public void Initialize(IModuleConfiguration config)
         {
             Guard.AgainstNullArgument("config", config);


### PR DESCRIPTION
When the executing runtime is Mono, we don't need to be reminded every time with `"Mono Engine initialized!"`.

The logging in ModuleLoader already tells us which engine is being loaded.
