### PR TITLE
refactor: disambiguate ParseOptions.ctor call for Xamarin

### DIFF
--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -160,7 +160,12 @@ namespace ScriptCs.Engine.Roslyn
 
         private static bool IsCompleteSubmission(string code)
         {
-            var options = new ParseOptions(kind: SourceCodeKind.Interactive);
+            var options = new ParseOptions(
+                CompatibilityMode.None,
+                LanguageVersion.CSharp4,
+                true,
+                SourceCodeKind.Interactive,
+                default(ReadOnlyArray<string>));
 
             var syntaxTree = SyntaxTree.ParseText(code, options: options);
 


### PR DESCRIPTION
fixes #736 
