### PR TITLE
Add engine tests for Mono

### DIFF
--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -5,6 +5,7 @@
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
+  <package id="Mono.CSharp" version="3.4.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="NuGet.Core" version="2.8.2" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />

--- a/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
@@ -1,0 +1,305 @@
+﻿extern alias MonoCSharp;
+
+using System.Linq;
+
+using Common.Logging;
+using Moq;
+using MonoCSharp::Mono.CSharp;
+using Ploeh.AutoFixture.Xunit;
+
+using ScriptCs.Tests;
+using ScriptCs.Contracts;
+
+using Should;
+
+using Xunit.Extensions;
+
+namespace ScriptCs.Engine.Mono.Tests
+{
+    public class MonoScriptEngineTests
+    {
+        public class TheExecuteMethod
+        {
+            [Theory, ScriptCsAutoData]
+            public void ShouldCreateScriptHostWithContexts(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [Frozen] Mock<IScriptPack> scriptPack,
+                ScriptPackSession scriptPackSession,
+                [NoAutoProperties] MonoScriptEngine engine)
+            {
+                // Arrange
+                const string Code = "var a = 0;";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                scriptPack.Setup(p => p.Initialize(It.IsAny<IScriptPackSession>()));
+                scriptPack.Setup(p => p.GetContext()).Returns((IScriptPackContext)null);
+
+                // Act
+                engine.Execute(Code, new string[0], new AssemblyReferences(), Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                scriptHostFactory.Verify(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()));
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReuseExistingSessionIfProvided(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoTestScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var a = 0;";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+
+                // Act
+                engine.Execute(Code, new string[0], new AssemblyReferences(), Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                engine.Session.ShouldEqual(session.Session);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldCreateNewSessionIfNotProvided(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoTestScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var a = 0;";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                // Act
+                engine.Execute(Code, new string[0], new AssemblyReferences(), Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                engine.Session.ShouldNotBeNull();
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldAddNewReferencesIfTheyAreProvided(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoTestScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var a = 0;";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                ((SessionState<Evaluator>)scriptPackSession.State[MonoScriptEngine.SessionKey]).References.PathReferences.Count().ShouldEqual(1);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnAScriptResult(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                var code = string.Empty;
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ShouldBeType<ScriptResult>();
+            }
+
+            // Need to get the compiler ex from mono.
+            // Currently the ConsoleReportWriter is swallowing the ex
+            /*            
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnCompileExceptionIfCodeDoesNotCompile(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "this shold not compile";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                System.Threading.Thread.Sleep(1000);
+
+                // Assert
+                result.CompileExceptionInfo.ShouldNotBeNull();
+            }
+            */
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldNotReturnCompileExceptionIfCodeDoesCompile(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var theNumber = 42; //this should compile";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ShouldBeType<ScriptResult>();
+                result.CompileExceptionInfo.ShouldBeNull();
+                result.ExecuteExceptionInfo.ShouldBeNull();
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnExecuteExceptionIfCodeExecutionThrowsException(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "throw new System.Exception(); //this should throw an Exception";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ExecuteExceptionInfo.ShouldNotBeNull();
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldNotReturnExecuteExceptionIfCodeExecutionDoesNotThrowAnException(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var theNumber = 42; //this should not throw an Exception";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ExecuteExceptionInfo.ShouldBeNull();
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnReturnValueIfCodeExecutionReturnsValue(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Mono doesn't support comments after evals as well as Roslyn
+                const string Code = "\"Hello\"";  //this should return \"Hello\"";
+
+                // Arrange
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ReturnValue.ShouldEqual("Hello");
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldNotReturnReturnValueIfCodeExecutionDoesNotReturnValue(
+                [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
+                [NoAutoProperties] MonoScriptEngine engine,
+                ScriptPackSession scriptPackSession)
+            {
+                // Arrange
+                const string Code = "var theNumber = 42; //this should not return a value";
+
+                scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+
+                var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext( new CompilerSettings(), new ConsoleReportPrinter())) };
+                scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
+                var refs = new AssemblyReferences();
+                refs.PathReferences.Add("System");
+
+                // Act
+                var result = engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);
+
+                // Assert
+                result.ReturnValue.ShouldBeNull();
+            }
+        }
+
+        public class MonoTestScriptEngine : MonoScriptEngine
+        {
+            public MonoTestScriptEngine(IScriptHostFactory scriptHostFactory, ILog logger)
+                : base(scriptHostFactory, logger)
+            {
+            }
+
+            public Evaluator Session { get; private set; }
+
+            protected override ScriptResult Execute(string code, Evaluator session)
+            {
+                Session = session;
+                return ScriptResult.Empty;
+            }
+        }
+    }
+}

--- a/test/ScriptCs.Engine.Mono.Tests/ScriptCs.Engine.Mono.Tests.csproj
+++ b/test/ScriptCs.Engine.Mono.Tests/ScriptCs.Engine.Mono.Tests.csproj
@@ -13,6 +13,8 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <TargetFrameworkProfile />
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <CodeAnalysisRuleSet>..\..\ScriptCs.Test.ruleset</CodeAnalysisRuleSet>
+    <NoWarn>1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +24,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>1701</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -33,34 +34,76 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="MonoModuleTest.cs" />
+    <Compile Include="..\ScriptCsAutoDataAttribute.cs">
+      <Link>ScriptCsAutoDataAttribute.cs</Link>
+    </Compile>
+    <Compile Include="..\ScriptCsMoqCustomization.cs">
+      <Link>ScriptCsMoqCustomization.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Parser\SyntaxParserTests.cs" />
+    <Compile Include="MonoModuleTest.cs" />
+    <Compile Include="MonoScriptEngineTests.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Common.Logging">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture">
+      <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq">
+      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.18.8\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture.Xunit">
+      <HintPath>..\..\packages\AutoFixture.Xunit.3.18.8\lib\net40\Ploeh.AutoFixture.Xunit.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
+    <Reference Include="System" />
     <Reference Include="xunit">
       <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
     </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Reference Include="xunit.extensions">
+      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.CSharp">
+      <HintPath>..\..\packages\Mono.CSharp.3.4.0\lib\net40\Mono.CSharp.dll</HintPath>
+      <Aliases>MonoCSharp</Aliases>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\ScriptCs.Contracts\ScriptCs.Contracts.csproj">
-      <Project>{6049e205-8b5f-4080-b023-70600e51fd64}</Project>
+      <Project>{6049E205-8B5F-4080-B023-70600E51FD64}</Project>
       <Name>ScriptCs.Contracts</Name>
     </ProjectReference>
+    <ProjectReference Include="..\..\src\ScriptCs.Core\ScriptCs.Core.csproj">
+      <Project>{E590E710-E159-48E6-A3E6-1A83D3FE732C}</Project>
+      <Name>ScriptCs.Core</Name>
+    </ProjectReference>
     <ProjectReference Include="..\..\src\ScriptCs.Engine.Mono\ScriptCs.Engine.Mono.csproj">
-      <Project>{e4adcfee-ff3b-4ef5-8298-2b31f407f58b}</Project>
+      <Project>{E4ADCFEE-FF3B-4EF5-8298-2B31F407F58B}</Project>
       <Name>ScriptCs.Engine.Mono</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets'))" />
+  </Target>
 </Project>

--- a/test/ScriptCs.Engine.Mono.Tests/app.config
+++ b/test/ScriptCs.Engine.Mono.Tests/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/ScriptCs.Engine.Mono.Tests/packages.config
+++ b/test/ScriptCs.Engine.Mono.Tests/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Mono.CSharp" version="3.4.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
This PR adds the same engine script tests for Mono that are testing the Roslyn Engine.

This fixes #663 (at least partly)

Two things purposely left out to keep this PR cleaner and are part of other issues.
- Mono Engine does not throw CompileException and needs to be implemented.  Currently the <Code>ConsoleReportWriter</code> is displaying but "swallowing" the exceptions.  This issue is more connected to #664.
- Mono Engine does not support IsCompleteSubmission and therefore has no tests around that feature.  The engine tests around this should be included in the PR that fixes #665.
