### PR TITLE
made basic ScriptExecution acceptance tests run under both debug and non-debug

### DIFF
--- a/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
@@ -10,30 +10,34 @@
     public static class ScriptExecution
     {
         [Scenario]
-        public static void HelloWorld(ScriptFile script, string output)
+        [Example(true)]
+        [Example(false)]
+        public static void HelloWorld(bool debug, ScriptFile script, string output)
         {
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a hello world script"
                 .f(() => script = ScriptFile.Create(scenario).WriteLine(@"Console.WriteLine(""Hello world!"");"));
 
-            "When I execute the script"
-                .f(() => output = script.Execute());
+            "When I execute the script with debug set to {0}"
+                .f(() => output = script.Execute(debug));
 
             "Then I see 'Hello world!'"
                 .f(() => output.ShouldContain("Hello world!"));
         }
 
         [Scenario]
-        public static void ScriptThrowsAnException(ScriptFile script, Exception ex)
+        [Example(true)]
+        [Example(false)]
+        public static void ScriptThrowsAnException(bool debug, ScriptFile script, Exception ex)
         {
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which throws an exception"
                 .f(() => script = ScriptFile.Create(scenario).WriteLine(@"throw new Exception(""BOOM!"");"));
 
-            "When I execute the script"
-                .f(() => ex = Record.Exception(() => script.Execute()));
+            "When I execute the script with debug set to {0}"
+                .f(() => ex = Record.Exception(() => script.Execute(debug)));
 
             "Then the script fails"
                 .f(() => ex.ShouldNotBeNull());

--- a/test/ScriptCs.Tests.Acceptance/Support/ScriptCsExe.cs
+++ b/test/ScriptCs.Tests.Acceptance/Support/ScriptCsExe.cs
@@ -4,15 +4,17 @@
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
 
     public static class ScriptCsExe
     {
         private static readonly bool isMono = Type.GetType("Mono.Runtime") != null;
 
-        public static string Execute(string[] args, string[] scriptArgs, string logFile, string workingDirectory)
+        public static string Execute(
+            IEnumerable<string> args, IEnumerable<string> scriptArgs, string logFile, string workingDirectory)
         {
             var commandArgs = new List<string>(args);
-            if (scriptArgs.Length > 0)
+            if (scriptArgs.Count() > 0)
             {
                 commandArgs.Add("--");
                 commandArgs.AddRange(scriptArgs);

--- a/test/ScriptCs.Tests.Acceptance/Support/ScriptFile.cs
+++ b/test/ScriptCs.Tests.Acceptance/Support/ScriptFile.cs
@@ -1,7 +1,9 @@
 ﻿namespace ScriptCs.Tests.Acceptance.Support
 {
+    using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.IO;
+    using System.Linq;
 
     public class ScriptFile
     {
@@ -45,9 +47,32 @@
             return this;
         }
 
-        public string Execute(params string[] scriptArgs)
+        public string Execute()
         {
-            return ScriptCsExe.Execute(new[] { this.name, "-debug" }, scriptArgs, this.log, directory);
+            return Execute(Enumerable.Empty<string>(), Enumerable.Empty<string>());
+        }
+
+        public string Execute(IEnumerable<string> args, IEnumerable<string> scriptArgs)
+        {
+            return Execute(true, args, scriptArgs);
+        }
+
+        public string Execute(bool debug)
+        {
+            return Execute(debug, Enumerable.Empty<string>(), Enumerable.Empty<string>());
+        }
+
+        public string Execute(bool debug, IEnumerable<string> args, IEnumerable<string> scriptArgs)
+        {
+            var debugArgs =
+                    debug &&
+                    !args.Select(arg => arg.Trim().ToUpperInvariant()).Contains("-DEBUG") &&
+                    !args.Select(arg => arg.Trim().ToUpperInvariant()).Contains("-D")
+                ? new[] { "-debug" }
+                : new string[0];
+
+            return ScriptCsExe.Execute(
+                new[] { this.name }.Concat(debugArgs).Concat(args), scriptArgs, this.log, directory);
         }
     }
 }


### PR DESCRIPTION
This was extracted from my previous PR #803.

Given that we have quite different execution paths (different engines) for debug and non-debug I think it's worth making at least the basic execution acceptance tests run under both conditions.
