### PR TITLE
switched off VS hosting for scriptcs.exe

### DIFF
--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -38,6 +38,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>..\..\ScriptCs.ruleset</CodeAnalysisRuleSet>
+    <UseVSHostingProcess>false</UseVSHostingProcess>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>


### PR DESCRIPTION
This has annoyed me for ever and today VS blocked a git clean one time too many times so here, finally, is a PR to remove VS hosting.

> git clean -fxd
> ...
> Unlink of file 'src/ScriptCs/bin/Debug/scriptcs.vshost.exe' failed. Should I try again? (y/n)
> :rage:

If anyone can cite a good reason for keeping VS hosting switched on please say so and I'll kill the PR but at the moment all I can see is a PITA with no benefit.
