### PR TITLE
#775 Set loglevel when debug arg is provided

### DIFF
--- a/src/ScriptCs/Argument/ArgumentHandler.cs
+++ b/src/ScriptCs/Argument/ArgumentHandler.cs
@@ -31,6 +31,11 @@ namespace ScriptCs.Argument
             var configArgs = _configFileParser.Parse(GetFileContent(commandArgs != null ? commandArgs.Config : "scriptcs.opts"));
             var finalArguments = ReconcileArguments(configArgs ?? new ScriptCsArgs(), commandArgs, sr);
 
+            if (finalArguments.Debug)
+            {
+                finalArguments.LogLevel = LogLevel.Debug;
+            }
+
             return new ArgumentParseResult(args, finalArguments, sr.ScriptArguments);
         }
 

--- a/src/ScriptCs/Argument/ArgumentParser.cs
+++ b/src/ScriptCs/Argument/ArgumentParser.cs
@@ -37,11 +37,6 @@ namespace ScriptCs.Argument
 
                 commandArgs = Args.Parse<ScriptCsArgs>(args);
 
-                if (commandArgs.Debug)
-                {
-                    commandArgs.LogLevel = LogLevel.Debug;
-                }
-
                 //if there is only 1 arg and it is a loglevel, it's also REPL
                 if (args.Length == 2 && args.Any(x => x.ToLowerInvariant() == "-loglevel" || x.ToLowerInvariant() == "-log"))
                 {

--- a/test/ScriptCs.Tests/ArgumentHandlerTests.cs
+++ b/test/ScriptCs.Tests/ArgumentHandlerTests.cs
@@ -167,6 +167,30 @@ namespace ScriptCs.Tests
 
                 system.Verify(x => x.FileExists(@"C:\scriptcs.opts"), Times.Once());
             }
+
+            [Fact]
+            public void ShouldSetLogLevelToDebugWhenDebugIsSetOnCommandLine()
+            {
+                var argumentHandler = Setup(null);
+                string[] args = { "server.csx", "-debug" };
+
+                var result = argumentHandler.Parse(args);
+
+                result.CommandArguments.Debug.ShouldBeTrue();
+                result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Debug);
+            }
+
+            [Fact]
+            public void ShouldSetLogLevelToDebugWhenDebugIsSetInOptsFile()
+            {
+                var argumentHandler = Setup("{ Debug: \"True\" }");
+                string[] args = { "server.csx" };
+
+                var result = argumentHandler.Parse(args);
+
+                result.CommandArguments.Debug.ShouldBeTrue();
+                result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Debug);
+            }
         }
     }
 }

--- a/test/ScriptCs.Tests/ArgumentParserTests.cs
+++ b/test/ScriptCs.Tests/ArgumentParserTests.cs
@@ -122,18 +122,6 @@ namespace ScriptCs.Tests
                 result.PackageVersion.ShouldEqual("1.0.1");
                 result.Install.ShouldEqual("glimpse.scriptcs");
             }
-
-            [Fact]
-            public void ShouldAutmoaticallySetLogLevelDebugIfDebugFlagIsPassed()
-            {
-                string[] args = { "test.csx", "-debug" };
-
-                var parser = new ArgumentParser(new ScriptConsole());
-                var result = parser.Parse(args);
-
-                result.Debug.ShouldBeTrue();
-                result.LogLevel.ShouldEqual(LogLevel.Debug);
-            }
         }
     }
 }


### PR DESCRIPTION
Moved the logic that sets LogLevel to debug when Debug is provided from
ArgumentParser to ArgumentHandler.

Added tests for when Debug is provided on command line and in the opts
file.

Removed test from the ArgumentParserTests that is no longer valid.
