### PR TITLE
#427 Add an ":exit" command to the REPL

### DIFF
--- a/src/ScriptCs.Contracts/IRepl.cs
+++ b/src/ScriptCs.Contracts/IRepl.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+using System.Reflection;
+
+namespace ScriptCs.Contracts
+{
+    public interface IRepl : IScriptExecutor
+    {
+        void Quit();
+    }
+}

--- a/src/ScriptCs.Contracts/IReplCommand.cs
+++ b/src/ScriptCs.Contracts/IReplCommand.cs
@@ -4,6 +4,6 @@
     {
         string CommandName { get; }
 
-        object Execute(IScriptExecutor repl, object[] args);
+        object Execute(IRepl repl, object[] args);
     }
 }

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -73,6 +73,7 @@
     <Compile Include="IPackageInstaller.cs" />
     <Compile Include="IPackageObject.cs" />
     <Compile Include="IPackageReference.cs" />
+    <Compile Include="IRepl.cs" />
     <Compile Include="IReplCommand.cs" />
     <Compile Include="IScriptEngine.cs" />
     <Compile Include="IScriptExecutor.cs" />

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -8,7 +8,7 @@ using ScriptCs.Contracts;
 
 namespace ScriptCs
 {
-    public class Repl : ScriptExecutor
+    public class Repl : ScriptExecutor, IRepl
     {
         private readonly string[] _scriptArgs;
 
@@ -161,6 +161,12 @@ namespace ScriptCs
             {
                 Console.ResetColor();
             }
+        }
+
+        public void Quit()
+        {
+            Terminate();
+            Environment.Exit(0);
         }
 
         private static string GetInvalidCommandArgumentMessage(string argument)

--- a/src/ScriptCs.Core/ReplCommands/CdCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/CdCommand.cs
@@ -10,7 +10,7 @@ namespace ScriptCs.ReplCommands
             get { return "cd"; }
         }
 
-        public object Execute(IScriptExecutor repl, object[] args)
+        public object Execute(IRepl repl, object[] args)
         {
             Guard.AgainstNullArgument("repl", repl);
 

--- a/src/ScriptCs.Core/ReplCommands/ClearCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ClearCommand.cs
@@ -18,7 +18,7 @@ namespace ScriptCs.ReplCommands
             get { return "clear"; }
         }
 
-        public object Execute(IScriptExecutor repl, object[] args)
+        public object Execute(IRepl repl, object[] args)
         {
             _console.Clear();
             return null;

--- a/src/ScriptCs.Core/ReplCommands/CwdCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/CwdCommand.cs
@@ -19,7 +19,7 @@ namespace ScriptCs.ReplCommands
             get { return "cwd"; }
         }
 
-        public object Execute(IScriptExecutor repl, object[] args)
+        public object Execute(IRepl repl, object[] args)
         {
             Guard.AgainstNullArgument("repl", repl);
 

--- a/src/ScriptCs.Core/ReplCommands/ExitCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ExitCommand.cs
@@ -1,0 +1,39 @@
+﻿using ScriptCs.Contracts;
+
+namespace ScriptCs.ReplCommands
+{
+    public class ExitCommand : IReplCommand 
+    {
+        private readonly IConsole _console;
+
+        public string CommandName
+        {
+            get { return "exit"; }
+        }
+
+        public ExitCommand(IConsole console)
+        {
+            _console = console;
+        }
+
+        public object Execute(IRepl repl, object[] args)
+        {
+            var response = string.Empty;
+            var responseIsValid = false;
+
+            while (!responseIsValid)
+            {
+                _console.Write("Are you sure you wish to exit? (y/n): ");
+                response = _console.ReadLine() ?? string.Empty;
+                responseIsValid = response == "y" || response == "n";
+            }
+
+            if (response == "y")
+            {
+                repl.Quit();
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
@@ -34,7 +34,7 @@ namespace ScriptCs.ReplCommands
             get { return "install"; }
         }
 
-        public object Execute(IScriptExecutor repl, object[] args)
+        public object Execute(IRepl repl, object[] args)
         {
             Guard.AgainstNullArgument("repl", repl);
 

--- a/src/ScriptCs.Core/ReplCommands/ResetCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ResetCommand.cs
@@ -9,7 +9,7 @@ namespace ScriptCs.ReplCommands
             get { return "reset"; }
         }
 
-        public object Execute(IScriptExecutor repl, object[] args)
+        public object Execute(IRepl repl, object[] args)
         {
             Guard.AgainstNullArgument("repl", repl);
 

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -67,6 +67,7 @@
     <Compile Include="FileSystem.cs" />
     <Compile Include="Guard.cs" />
     <Compile Include="ILoggerConfigurator.cs" />
+    <Compile Include="ReplCommands\ExitCommand.cs" />
     <Compile Include="ReplCommands\InstallCommand.cs" />
     <Compile Include="LoadLineProcessor.cs" />
     <Compile Include="PackageAssemblyResolver.cs" />

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -41,6 +41,7 @@ namespace ScriptCs.Hosting
             builder.RegisterType(_scriptEngineType).As<IScriptEngine>().SingleInstance();
             builder.RegisterType(_scriptExecutorType).As<IScriptExecutor>().SingleInstance();
             builder.RegisterType<ScriptServices>().SingleInstance();
+            builder.RegisterType<Repl>().As<IRepl>().SingleInstance();
 
             RegisterLineProcessors(builder);
             RegisterReplCommands(builder);

--- a/test/ScriptCs.Core.Tests/ReplCommands/CdCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/CdCommandTests.cs
@@ -29,7 +29,7 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var fs = new Mock<IFileSystem>();
-                var executor = new Mock<Contracts.IRepl>();
+                var executor = new Mock<IRepl>();
 
                 var tempPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
 

--- a/test/ScriptCs.Core.Tests/ReplCommands/CdCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/CdCommandTests.cs
@@ -29,7 +29,7 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var fs = new Mock<IFileSystem>();
-                var executor = new Mock<IScriptExecutor>();
+                var executor = new Mock<Contracts.IRepl>();
 
                 var tempPath = Path.GetTempPath().TrimEnd(Path.DirectorySeparatorChar);
 

--- a/test/ScriptCs.Core.Tests/ReplCommands/ClearCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ClearCommandTests.cs
@@ -30,7 +30,7 @@ namespace ScriptCs.Tests.ReplCommands
                 var cmd = new ClearCommand(console.Object);
 
                 // act
-                cmd.Execute(new Mock<IScriptExecutor>().Object, null);
+                cmd.Execute(new Mock<Contracts.IRepl>().Object, null);
 
                 // assert
                 console.Verify(x => x.Clear(), Times.Once);

--- a/test/ScriptCs.Core.Tests/ReplCommands/ClearCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ClearCommandTests.cs
@@ -30,7 +30,7 @@ namespace ScriptCs.Tests.ReplCommands
                 var cmd = new ClearCommand(console.Object);
 
                 // act
-                cmd.Execute(new Mock<Contracts.IRepl>().Object, null);
+                cmd.Execute(new Mock<IRepl>().Object, null);
 
                 // assert
                 console.Verify(x => x.Clear(), Times.Once);

--- a/test/ScriptCs.Core.Tests/ReplCommands/CwdCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/CwdCommandTests.cs
@@ -30,7 +30,7 @@ namespace ScriptCs.Tests.ReplCommands
                 // arrange
                 var console = new Mock<IConsole>();
                 var fs = new Mock<IFileSystem>();
-                var executor = new Mock<IScriptExecutor>();
+                var executor = new Mock<Contracts.IRepl>();
 
                 var tempPath = Path.GetTempPath();
 
@@ -51,7 +51,7 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var console = new Mock<IConsole>();
-                var executor = new Mock<IScriptExecutor>();
+                var executor = new Mock<Contracts.IRepl>();
 
                 console.SetupProperty(x => x.ForegroundColor);
                 executor.Setup(x => x.FileSystem).Returns(new Mock<IFileSystem>().Object);

--- a/test/ScriptCs.Core.Tests/ReplCommands/CwdCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/CwdCommandTests.cs
@@ -51,7 +51,7 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var console = new Mock<IConsole>();
-                var executor = new Mock<Contracts.IRepl>();
+                var executor = new Mock<IRepl>();
 
                 console.SetupProperty(x => x.ForegroundColor);
                 executor.Setup(x => x.FileSystem).Returns(new Mock<IFileSystem>().Object);

--- a/test/ScriptCs.Core.Tests/ReplCommands/ExitCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ExitCommandTests.cs
@@ -28,6 +28,7 @@ namespace ScriptCs.Tests.ReplCommands
                 // arrange
                 const string message = "Are you sure you wish to exit? (y/n): ";
                 var console = new Mock<IConsole>();
+                console.Setup(x => x.ReadLine()).Returns("n");
                 var executor = new Mock<IRepl>();
                 var cmd = new ExitCommand(console.Object);
 

--- a/test/ScriptCs.Core.Tests/ReplCommands/ExitCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ExitCommandTests.cs
@@ -1,0 +1,76 @@
+﻿using Moq;
+using ScriptCs.Contracts;
+using ScriptCs.ReplCommands;
+using Xunit;
+
+namespace ScriptCs.Tests.ReplCommands
+{
+    public class ExitCommandTests
+    {
+        public class CommandNameProperty
+        {
+            [Fact]
+            public void ReturnsExit()
+            {
+                // act
+                var cmd = new ExitCommand(new Mock<IConsole>().Object);
+
+                // assert
+                Assert.Equal("exit", cmd.CommandName);
+            }
+        }
+
+        public class ExecuteMethod
+        {
+            [Fact]
+            public void PromptsUserBeforeExiting()
+            {
+                // arrange
+                const string message = "Are you sure you wish to exit? (y/n): ";
+                var console = new Mock<IConsole>();
+                var executor = new Mock<IRepl>();
+                var cmd = new ExitCommand(console.Object);
+
+                // act
+                cmd.Execute(executor.Object, null);
+
+                // assert
+                console.Verify(x => x.Write(message));
+            }
+
+            [Fact]
+            public void ExitsWhenUserAnswersYes()
+            {
+                // arrange
+                var console = new Mock<IConsole>();
+                console.Setup(x => x.ReadLine()).Returns("y");
+
+                var executor = new Mock<IRepl>();
+                var cmd = new ExitCommand(console.Object);
+
+                // act
+                cmd.Execute(executor.Object, null);
+
+                // assert
+                executor.Verify(x => x.Quit());
+            }
+
+            [Fact]
+            public void DoesNotExitWhenUserAnswersNo()
+            {
+                // arrange
+                var console = new Mock<IConsole>();
+                console.Setup(x => x.ReadLine()).Returns("n");
+
+                var executor = new Mock<IRepl>();
+                var cmd = new ExitCommand(console.Object);
+
+                // act
+                cmd.Execute(executor.Object, null);
+
+                // assert
+                executor.Verify(x => x.Quit(), Times.Never);
+            }
+        }
+    }
+}

--- a/test/ScriptCs.Core.Tests/ReplCommands/InstallCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/InstallCommandTests.cs
@@ -43,7 +43,7 @@ namespace ScriptCs.Tests.ReplCommands
                 _packageAssemblyResolver = new Mock<IPackageAssemblyResolver>();
                 _logger = new Mock<ILog>();
                 _installationProvider = new Mock<IInstallationProvider>();
-                _executor = new Mock<Contracts.IRepl>();
+                _executor = new Mock<IRepl>();
 
                 var fs = new Mock<IFileSystem>();
                 fs.Setup(x => x.CurrentDirectory).Returns(@"c:\dir");

--- a/test/ScriptCs.Core.Tests/ReplCommands/InstallCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/InstallCommandTests.cs
@@ -35,7 +35,7 @@ namespace ScriptCs.Tests.ReplCommands
             private readonly Mock<IPackageAssemblyResolver> _packageAssemblyResolver;
             private readonly Mock<ILog> _logger;
             private readonly Mock<IInstallationProvider> _installationProvider;
-            private Mock<IScriptExecutor> _executor;
+            private Mock<Contracts.IRepl> _executor;
 
             public ExecuteMethod()
             {
@@ -43,7 +43,7 @@ namespace ScriptCs.Tests.ReplCommands
                 _packageAssemblyResolver = new Mock<IPackageAssemblyResolver>();
                 _logger = new Mock<ILog>();
                 _installationProvider = new Mock<IInstallationProvider>();
-                _executor = new Mock<IScriptExecutor>();
+                _executor = new Mock<Contracts.IRepl>();
 
                 var fs = new Mock<IFileSystem>();
                 fs.Setup(x => x.CurrentDirectory).Returns(@"c:\dir");

--- a/test/ScriptCs.Core.Tests/ReplCommands/ResetCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ResetCommandTests.cs
@@ -26,7 +26,7 @@ namespace ScriptCs.Tests.ReplCommands
             public void CallsReplReset()
             {
                 // arrange
-                var executor = new Mock<Contracts.IRepl>();
+                var executor = new Mock<IRepl>();
 
                 var cmd = new ResetCommand();
 

--- a/test/ScriptCs.Core.Tests/ReplCommands/ResetCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ResetCommandTests.cs
@@ -26,7 +26,7 @@ namespace ScriptCs.Tests.ReplCommands
             public void CallsReplReset()
             {
                 // arrange
-                var executor = new Mock<IScriptExecutor>();
+                var executor = new Mock<Contracts.IRepl>();
 
                 var cmd = new ResetCommand();
 

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -603,7 +603,7 @@ namespace ScriptCs.Tests
 
                 var helloCommand = new Mock<IReplCommand>();
                 helloCommand.SetupGet(x => x.CommandName).Returns("hello");
-                helloCommand.Setup(x => x.Execute(It.IsAny<Contracts.IRepl>(), It.IsAny<object[]>()))
+                helloCommand.Setup(x => x.Execute(It.IsAny<IRepl>(), It.IsAny<object[]>()))
                     .Returns(returnValue);
 
                 var mocks = new Mocks { ReplCommands = new[] { helloCommand } };
@@ -624,7 +624,7 @@ namespace ScriptCs.Tests
 
                 var helloCommand = new Mock<IReplCommand>();
                 helloCommand.SetupGet(x => x.CommandName).Returns("hello");
-                helloCommand.Setup(x => x.Execute(It.IsAny<Contracts.IRepl>(), It.IsAny<object[]>()))
+                helloCommand.Setup(x => x.Execute(It.IsAny<IRepl>(), It.IsAny<object[]>()))
                     .Returns(returnValue);
 
                 var mocks = new Mocks { ReplCommands = new[] { helloCommand } };

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -603,7 +603,7 @@ namespace ScriptCs.Tests
 
                 var helloCommand = new Mock<IReplCommand>();
                 helloCommand.SetupGet(x => x.CommandName).Returns("hello");
-                helloCommand.Setup(x => x.Execute(It.IsAny<IScriptExecutor>(), It.IsAny<object[]>()))
+                helloCommand.Setup(x => x.Execute(It.IsAny<Contracts.IRepl>(), It.IsAny<object[]>()))
                     .Returns(returnValue);
 
                 var mocks = new Mocks { ReplCommands = new[] { helloCommand } };
@@ -624,7 +624,7 @@ namespace ScriptCs.Tests
 
                 var helloCommand = new Mock<IReplCommand>();
                 helloCommand.SetupGet(x => x.CommandName).Returns("hello");
-                helloCommand.Setup(x => x.Execute(It.IsAny<IScriptExecutor>(), It.IsAny<object[]>()))
+                helloCommand.Setup(x => x.Execute(It.IsAny<Contracts.IRepl>(), It.IsAny<object[]>()))
                     .Returns(returnValue);
 
                 var mocks = new Mocks { ReplCommands = new[] { helloCommand } };

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -59,6 +59,7 @@
     <Compile Include="ReplCommands\CdCommandTests.cs" />
     <Compile Include="ReplCommands\ClearCommandTests.cs" />
     <Compile Include="ReplCommands\CwdCommandTests.cs" />
+    <Compile Include="ReplCommands\ExitCommandTests.cs" />
     <Compile Include="ReplCommands\InstallCommandTests.cs" />
     <Compile Include="ReplCommands\ResetCommandTests.cs" />
     <Compile Include="ReplTests.cs" />


### PR DESCRIPTION
Added new IRepl interface that inherits from IScriptExecutor and adds a new method named Quit

Updated the Execute method of IRepl to accept an instance of IRepl instead of IScriptExecutor

Updated Repl to implement IRepl and the new Quit method, which calls Terminate() and Environment.Exit(0)

Updated the Execute() method of the existing REPL commands to accept an instance of IRepl instead of IScriptExecutor

Added a new ExitCommand that uses the new Repl.Quit() method to exit the REPL

Updated RuntimeServices to bind IRepl to Repl

Updated existing REPL command tests to pass in a mock of IRepl to IReplCommand.Execute instead of a mock of IScriptExecutor

Added new tests to cover the new ExitCommand