### PR TITLE
Remove InteractiveBase from MonoHost

### DIFF
--- a/src/ScriptCs.Engine.Mono/MonoHost.cs
+++ b/src/ScriptCs.Engine.Mono/MonoHost.cs
@@ -5,7 +5,7 @@ using ScriptCs.Contracts;
 
 namespace ScriptCs.Engine.Mono
 {
-    public class MonoHost : InteractiveBase, IScriptHost
+    public class MonoHost : IScriptHost
     {
         private static ScriptHost _scriptHost;
 


### PR DESCRIPTION
Turns out the base `InteractiveBase` class is not needed in mono for anything - it only brings in the static members which are then surfaced in REPL.

Everything works without it, and it solves our problems that people are seeing Mono's help and other commands.

 Solves #818
