### PR TITLE
Update Chocolatey install command

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,10 +56,7 @@
 <li>Script Packs allow you to bootstrap the environment for new scripts, further reduces the amount of code necessary to take advantage of your favorite C# frameworks.</li>
 </ul><h2>Getting scriptcs</h2>
 
-<p>Releases and nightly builds should be installed using <a href="http://chocolatey.org/">Chocolatey</a>. To install Chocolatey, execute the following command in your command prompt:</p>
-
-<pre><code>@powershell -NoProfile -ExecutionPolicy Unrestricted -Command "iex ((New-Object Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" &amp;&amp; SET PATH=%PATH%;%systemdrive%\chocolatey\bin
-</code></pre>
+<p>Releases and nightly builds should be installed using <a href="https://chocolatey.org/">Chocolatey</a>. Information on installing Chocolatey is available at their website.</p>
 
 <h3>Installing scriptcs</h3>
 


### PR DESCRIPTION
Chocolatey now installs to the %ALLUSERSPROFILE% directory instead of %SYSTEMDRIVE% for security reasons.
