### PR TITLE
#833 The "trace" log level is allowed when debug is specified.

### DIFF
--- a/src/ScriptCs/Argument/ArgumentHandler.cs
+++ b/src/ScriptCs/Argument/ArgumentHandler.cs
@@ -34,7 +34,7 @@ namespace ScriptCs.Argument
             var globalConfigArgs = _configFileParser.Parse(GetFileContent(_fileSystem.GlobalOptsFile));
             var finalArguments = ReconcileArguments(globalConfigArgs, localConfigArgs, commandArgs, sr);
 
-            if (finalArguments.Debug)
+            if (finalArguments.Debug && finalArguments.LogLevel < LogLevel.Debug)
             {
                 finalArguments.LogLevel = LogLevel.Debug;
             }

--- a/test/ScriptCs.Tests/ArgumentHandlerTests.cs
+++ b/test/ScriptCs.Tests/ArgumentHandlerTests.cs
@@ -264,6 +264,30 @@ namespace ScriptCs.Tests
                 result.CommandArguments.Debug.ShouldBeTrue();
                 result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Debug);
             }
+
+            [Fact]
+            public void ShouldAllowTraceLogLevelWhenDebugIsSet()
+            {
+                var argumentHandler = Setup(null);
+                string[] args = { "server.csx", "-debug", "-log", "trace" };
+
+                var result = argumentHandler.Parse(args);
+
+                result.CommandArguments.Debug.ShouldBeTrue();
+                result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Trace);
+            }
+
+            [Fact]
+            public void ShouldSetLogLevelToDebugWhenDebugIsSetAndLogLevelIsLowerThanDebug()
+            {
+                var argumentHandler = Setup(null);
+                string[] args = { "server.csx", "-debug", "-log", "info" };
+
+                var result = argumentHandler.Parse(args);
+
+                result.CommandArguments.Debug.ShouldBeTrue();
+                result.CommandArguments.LogLevel.ShouldEqual(LogLevel.Debug);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #833, though in a different way than recommended by @khellang.

@Romoku's problem was that they were not able to use the `trace` log level when using `-debug` which this fixes. However lower log levels (`info` and `error`) will still be converted to `debug` when using the `-debug` flag.

The originally suggested fix of making `LogLevel` nullable had reasonably far reaching consequences, but I think that this is a simpler way of addressing the original issue.
