### PR TITLE
made FileWatcher threadsafe

### DIFF
--- a/src/ScriptCs/Command/FileWatcher.cs
+++ b/src/ScriptCs/Command/FileWatcher.cs
@@ -27,25 +27,28 @@ namespace ScriptCs.Command
 
         public void Start()
         {
-            if (_timer != null)
+            lock (_timerLock)
             {
-                return;
-            }
+                if (_timer != null)
+                {
+                    return;
+                }
 
-            _lastWriteTime = _fileSystem.GetLastWriteTime(_file);
-            _timer = new Timer(_ => CheckLastWriteTime(), null, Timeout.Infinite, Timeout.Infinite);
-            _timer.Change(_intervalMilliseconds, Timeout.Infinite);
+                _lastWriteTime = _fileSystem.GetLastWriteTime(_file);
+                _timer = new Timer(_ => CheckLastWriteTime(), null, Timeout.Infinite, Timeout.Infinite);
+                _timer.Change(_intervalMilliseconds, Timeout.Infinite);
+            }
         }
 
         public void Stop()
         {
-            if (_timer == null)
-            {
-                return;
-            }
-
             lock (_timerLock)
             {
+                if (_timer == null)
+                {
+                    return;
+                }
+
                 _timer.Dispose();
                 _timer = null;
             }

--- a/src/ScriptCs/Command/FileWatcher.cs
+++ b/src/ScriptCs/Command/FileWatcher.cs
@@ -6,13 +6,13 @@ namespace ScriptCs.Command
 {
     public sealed class FileWatcher : IDisposable
     {
+        private readonly object _timerLock = new object();
         private readonly string _file;
-        private readonly int _intervalMilliseconds = 500;
+        private readonly int _intervalMilliseconds;
         private readonly IFileSystem _fileSystem;
 
         private DateTime _lastWriteTime;
         private Timer _timer;
-        private object _timerLock = new object();
 
         public FileWatcher(string file, int intervalMilliseconds, IFileSystem fileSystem)
         {
@@ -37,7 +37,7 @@ namespace ScriptCs.Command
             _timer.Change(_intervalMilliseconds, Timeout.Infinite);
         }
 
-        private void Stop()
+        public void Stop()
         {
             if (_timer == null)
             {
@@ -49,6 +49,11 @@ namespace ScriptCs.Command
                 _timer.Dispose();
                 _timer = null;
             }
+        }
+
+        public void Dispose()
+        {
+            Stop();
         }
 
         private void CheckLastWriteTime()
@@ -73,11 +78,6 @@ namespace ScriptCs.Command
 
                 _timer.Change(_intervalMilliseconds, Timeout.Infinite);
             }
-        }
-
-        public void Dispose()
-        {
-            Stop();
         }
     }
 }


### PR DESCRIPTION
The defect https://scan8.coverity.com:8443/reports.htm#v21582/p10801/fileInstanceId=3240428&defectInstanceId=1396798&mergedDefectId=96018 found by Coverity is actually a false positive since the locking was not in place to give public thread safety but only to guarantee correct implementation, given the internal timer thread, but reading the code, it was difficult to tell. I considered suppressing the warning but then I realised making the type threadsafe was actually a trivial change and removes ambiguity for the reader so I thought to go down that route instead.