### PR TITLE
#898 fix naming inconsistencies in IFileSystem methods and parameters

### DIFF
--- a/src/ScriptCs.Contracts/IFileSystem.cs
+++ b/src/ScriptCs.Contracts/IFileSystem.cs
@@ -7,13 +7,13 @@ namespace ScriptCs.Contracts
     public interface IFileSystem
     {
         IEnumerable<string> EnumerateFiles(
-            string dir, string search, SearchOption searchOption = SearchOption.AllDirectories);
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
 
         IEnumerable<string> EnumerateDirectories(
-            string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
 
         IEnumerable<string> EnumerateFilesAndDirectories(
-            string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
 
         void CopyFile(string source, string dest, bool overwrite);
 

--- a/src/ScriptCs.Contracts/IFileSystem.cs
+++ b/src/ScriptCs.Contracts/IFileSystem.cs
@@ -53,9 +53,9 @@ namespace ScriptCs.Contracts
 
         void WriteToFile(string path, string text);
 
-        Stream CreateFileStream(string filePath, FileMode mode);
+        Stream CreateFileStream(string path, FileMode mode);
 
-        void WriteAllBytes(string filePath, byte[] bytes);
+        void WriteAllBytes(string path, byte[] bytes);
 
         string GlobalFolder { get; }
 

--- a/src/ScriptCs.Contracts/IFileSystem.cs
+++ b/src/ScriptCs.Contracts/IFileSystem.cs
@@ -15,7 +15,7 @@ namespace ScriptCs.Contracts
         IEnumerable<string> EnumerateFilesAndDirectories(
             string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories);
 
-        void Copy(string source, string dest, bool overwrite);
+        void CopyFile(string source, string dest, bool overwrite);
 
         void CopyDirectory(string source, string dest, bool overwrite);
 
@@ -41,13 +41,13 @@ namespace ScriptCs.Contracts
 
         string GetWorkingDirectory(string path);
 
-        void Move(string source, string dest);
+        void MoveFile(string source, string dest);
 
         void MoveDirectory(string source, string dest);
 
         bool FileExists(string path);
 
-        void FileDelete(string path);
+        void DeleteFile(string path);
 
         IEnumerable<string> SplitLines(string value);
 
@@ -55,7 +55,7 @@ namespace ScriptCs.Contracts
 
         Stream CreateFileStream(string path, FileMode mode);
 
-        void WriteAllBytes(string path, byte[] bytes);
+        void WriteToFile(string path, byte[] bytes);
 
         string GlobalFolder { get; }
 

--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -8,21 +8,21 @@ namespace ScriptCs
     public class FileSystem : IFileSystem
     {
         public virtual IEnumerable<string> EnumerateFiles(
-            string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
         {
-            return Directory.EnumerateFiles(dir, searchPattern, searchOption);
+            return Directory.EnumerateFiles(path, searchPattern, searchOption);
         }
 
         public virtual IEnumerable<string> EnumerateDirectories(
-            string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
         {
-            return Directory.EnumerateDirectories(dir, searchPattern, searchOption);
+            return Directory.EnumerateDirectories(path, searchPattern, searchOption);
         }
 
         public virtual IEnumerable<string> EnumerateFilesAndDirectories(
-            string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+            string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
         {
-            return Directory.EnumerateFileSystemEntries(dir, searchPattern, searchOption);
+            return Directory.EnumerateFileSystemEntries(path, searchPattern, searchOption);
         }
 
         public virtual void CopyFile(string source, string dest, bool overwrite)

--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -135,14 +135,14 @@ namespace ScriptCs
             File.WriteAllText(path, text);
         }
 
-        public virtual Stream CreateFileStream(string filePath, FileMode mode)
+        public virtual Stream CreateFileStream(string path, FileMode mode)
         {
-            return new FileStream(filePath, mode);
+            return new FileStream(path, mode);
         }
 
-        public virtual void WriteAllBytes(string filePath, byte[] bytes)
+        public virtual void WriteAllBytes(string path, byte[] bytes)
         {
-            File.WriteAllBytes(filePath, bytes);
+            File.WriteAllBytes(path, bytes);
         }
 
         public virtual string GlobalFolder

--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -25,7 +25,7 @@ namespace ScriptCs
             return Directory.EnumerateFileSystemEntries(dir, searchPattern, searchOption);
         }
 
-        public virtual void Copy(string source, string dest, bool overwrite)
+        public virtual void CopyFile(string source, string dest, bool overwrite)
         {
             File.Copy(source, dest, overwrite);
         }
@@ -103,7 +103,7 @@ namespace ScriptCs
             return File.GetLastWriteTime(file);
         }
 
-        public virtual void Move(string source, string dest)
+        public virtual void MoveFile(string source, string dest)
         {
             File.Move(source, dest);
         }
@@ -118,7 +118,7 @@ namespace ScriptCs
             return File.Exists(path);
         }
 
-        public virtual void FileDelete(string path)
+        public virtual void DeleteFile(string path)
         {
             File.Delete(path);
         }
@@ -140,7 +140,7 @@ namespace ScriptCs
             return new FileStream(path, mode);
         }
 
-        public virtual void WriteAllBytes(string path, byte[] bytes)
+        public virtual void WriteToFile(string path, byte[] bytes)
         {
             File.WriteAllBytes(path, bytes);
         }

--- a/src/ScriptCs.Core/FileSystemMigrator.cs
+++ b/src/ScriptCs.Core/FileSystemMigrator.cs
@@ -70,7 +70,7 @@ namespace ScriptCs
                 _logger.InfoFormat(
                     CultureInfo.InvariantCulture, "Copying file '{0}' to '{1}'...", copy.Key, copy.Value);
 
-                _fileSystem.Copy(copy.Key, copy.Value, false);
+                _fileSystem.CopyFile(copy.Key, copy.Value, false);
             }
 
             foreach (var move in _directoryMoves

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -37,7 +37,7 @@ namespace ScriptCs.Engine.Roslyn
             }
 
             var dllPath = GetDllTargetPath();
-            _fileSystem.WriteAllBytes(dllPath, exeBytes);
+            _fileSystem.WriteToFile(dllPath, exeBytes);
 
             Logger.DebugFormat("Loading assembly {0}.", dllPath);
 

--- a/test/ScriptCs.Core.Tests/FileSystemMigratorTests.cs
+++ b/test/ScriptCs.Core.Tests/FileSystemMigratorTests.cs
@@ -68,10 +68,10 @@ namespace ScriptCs.Tests
                     f.MoveDirectory(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
 
                 fileSystem.Verify(f =>
-                    f.Copy(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
+                    f.CopyFile(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<bool>()), Times.Never);
 
                 fileSystem.Verify(f =>
-                    f.Move(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+                    f.MoveFile(It.IsAny<string>(), It.IsAny<string>()), Times.Never);
             }
         }
     }

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -414,7 +414,7 @@ namespace ScriptCs.Hosting.Tests
                     throw new NotImplementedException();
                 }
 
-                public void Copy(string source, string dest, bool overwrite)
+                public void CopyFile(string source, string dest, bool overwrite)
                 {
                     throw new NotImplementedException();
                 }
@@ -480,7 +480,7 @@ namespace ScriptCs.Hosting.Tests
                     throw new NotImplementedException();
                 }
 
-                public void Move(string source, string dest)
+                public void MoveFile(string source, string dest)
                 {
                     throw new NotImplementedException();
                 }
@@ -495,7 +495,7 @@ namespace ScriptCs.Hosting.Tests
                     throw new NotImplementedException();
                 }
 
-                public void FileDelete(string path)
+                public void DeleteFile(string path)
                 {
                     throw new NotImplementedException();
                 }
@@ -515,7 +515,7 @@ namespace ScriptCs.Hosting.Tests
                     throw new NotImplementedException();
                 }
 
-                public void WriteAllBytes(string path, byte[] bytes)
+                public void WriteToFile(string path, byte[] bytes)
                 {
                     throw new NotImplementedException();
                 }

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -510,12 +510,12 @@ namespace ScriptCs.Hosting.Tests
                     throw new NotImplementedException();
                 }
 
-                public Stream CreateFileStream(string filePath, FileMode mode)
+                public Stream CreateFileStream(string path, FileMode mode)
                 {
                     throw new NotImplementedException();
                 }
 
-                public void WriteAllBytes(string filePath, byte[] bytes)
+                public void WriteAllBytes(string path, byte[] bytes)
                 {
                     throw new NotImplementedException();
                 }

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -397,19 +397,19 @@ namespace ScriptCs.Hosting.Tests
             private class MockFileSystem : IFileSystem
             {
                 public IEnumerable<string> EnumerateFiles(
-                    string dir, string search, SearchOption searchOption = SearchOption.AllDirectories)
+                    string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
                 {
                     throw new NotImplementedException();
                 }
 
                 public IEnumerable<string> EnumerateDirectories(
-                    string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+                    string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
                 {
                     throw new NotImplementedException();
                 }
 
                 public IEnumerable<string> EnumerateFilesAndDirectories(
-                    string dir, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
+                    string path, string searchPattern, SearchOption searchOption = SearchOption.AllDirectories)
                 {
                     throw new NotImplementedException();
                 }


### PR DESCRIPTION
The parameter renames are just meant to be consistent with the rest of the file - does not break anything.
The method renaming are breaking changes. Marking them obsolete on the interface would still need the custom implementations implement both old and new API methods. 
Hence, did a rename, so that when the others pull, they also just rename the methods in their custom FileSystem implementations. 