### PR TITLE
Do not use initialize modules MEF catalog if the only module in play is Roslyn or Mono

### DIFF
--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -12,7 +12,7 @@ namespace ScriptCs.Hosting
 {
     public class ModuleLoader : IModuleLoader
     {
-        private static readonly Dictionary<string, string> DefaultCSharpModules = new Dictionary<string, string>
+        internal static readonly Dictionary<string, string> DefaultCSharpModules = new Dictionary<string, string>
         {
             {"roslyn", "ScriptCs.Engine.Roslyn.dll"},
             {"mono", "ScriptCs.Engine.Mono.dll"}

--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -12,7 +12,7 @@ namespace ScriptCs.Hosting
 {
     public class ModuleLoader : IModuleLoader
     {
-        private static Dictionary<string, string> defaultCSharpModules = new Dictionary<string, string>
+        private static readonly Dictionary<string, string> DefaultCSharpModules = new Dictionary<string, string>
         {
             {"roslyn", "ScriptCs.Engine.Roslyn.dll"},
             {"mono", "ScriptCs.Engine.Mono.dll"}
@@ -69,9 +69,10 @@ namespace ScriptCs.Hosting
         {
             if (modulePackagesPaths == null) return;
 
-            if (moduleNames.Length == 1) // only CSharp module needed
+            if (moduleNames.Length == 1 && DefaultCSharpModules.ContainsKey(moduleNames[0])) // only CSharp module needed
             {
-                var csharpModuleAssembly = defaultCSharpModules[moduleNames[0]];
+                _logger.Debug("Only CSharp module is needed - will skip module lookup");
+                var csharpModuleAssembly = DefaultCSharpModules[moduleNames[0]];
                 var module = _assemblyUtility.LoadFile(Path.Combine(hostBin, csharpModuleAssembly));
 
                 if (module != null)

--- a/src/ScriptCs.Hosting/Properties/AssemblyInfo.cs
+++ b/src/ScriptCs.Hosting/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
 ﻿using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("ScriptCs.Hosting")]
 [assembly: AssemblyDescription("ScriptCs.Hosting provides common services necessary for hosting scriptcs in your application.")]
+
+[assembly: InternalsVisibleTo("ScriptCs.Hosting.Tests")]

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Common.Logging;
 using ScriptCs.Contracts;
@@ -71,16 +72,17 @@ namespace ScriptCs.Hosting
         public IScriptServicesBuilder LoadModules(string extension, params string[] moduleNames)
         {
             var engineModule = _typeResolver.ResolveType("Mono.Runtime") != null || moduleNames.Contains("mono")
-                ? "mono" 
+                ? "mono"
                 : "roslyn";
-            
-            moduleNames = moduleNames.Union(new[] { engineModule }).ToArray();
+
+            moduleNames = moduleNames.Union(new[] {engineModule}).ToArray();
+
             var config = new ModuleConfiguration(_cache, _scriptName, _repl, _logLevel, _debug, Overrides);
             var loader = InitializationServices.GetModuleLoader();
 
             var fs = InitializationServices.GetFileSystem();
 
-            var folders = new[] { fs.GlobalFolder };
+            var folders = new[] {fs.GlobalFolder};
             loader.Load(config, folders, InitializationServices.GetFileSystem().HostBin, extension, moduleNames);
             return this;
         }

--- a/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
@@ -125,7 +125,6 @@ namespace ScriptCs.Hosting.Tests
             [Fact]
             public void ShouldLoadEngineModuleFromFile()
             {
-                var path = Path.Combine("c:\\foo", ModuleLoader.DefaultCSharpModules["roslyn"]);
                 _mockAssemblyUtility.Setup(x => x.LoadFile(It.IsAny<string>())).Returns(typeof (DummyModule).Assembly);
                 var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (a, c) => { }, _getModules, _mockFileSystem.Object, _mockAssemblyUtility.Object);
 

--- a/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
@@ -9,6 +9,7 @@ using Moq;
 using ScriptCs.Contracts;
 using Should;
 using Xunit;
+using LogLevel = ScriptCs.Contracts.LogLevel;
 
 namespace ScriptCs.Hosting.Tests
 {
@@ -110,6 +111,31 @@ namespace ScriptCs.Hosting.Tests
                 _mockModule1.Verify(m => m.Initialize(It.IsAny<IModuleConfiguration>()), Times.Never());
             }
 
+            [Fact]
+            public void ShouldLoadEngineAssemblyByHandIfItsTheOnlyModule()
+            {
+                var path = Path.Combine("c:\\foo", ModuleLoader.DefaultCSharpModules["roslyn"]);
+                _mockAssemblyUtility.Setup(x => x.LoadFile(path));
+                var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (a, c) => { }, _getModules, _mockFileSystem.Object, _mockAssemblyUtility.Object);
+                loader.Load(null, new string[0], "c:\\foo", null, "roslyn");
+
+                _mockAssemblyUtility.Verify(x => x.LoadFile(path), Times.Once());
+            }
+
+            [Fact]
+            public void ShouldLoadEngineModuleFromFile()
+            {
+                var path = Path.Combine("c:\\foo", ModuleLoader.DefaultCSharpModules["roslyn"]);
+                _mockAssemblyUtility.Setup(x => x.LoadFile(It.IsAny<string>())).Returns(typeof (DummyModule).Assembly);
+                var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (a, c) => { }, _getModules, _mockFileSystem.Object, _mockAssemblyUtility.Object);
+
+                var config = new ModuleConfiguration(true, string.Empty, false, LogLevel.Debug, true,
+                    new Dictionary<Type, object> {{typeof (string), "not loaded"}});
+                loader.Load(config, new string[0], "c:\\foo", null, "roslyn");
+
+                config.Overrides[typeof(string)].ShouldEqual("module loaded");
+            }
+
             public class ModuleMetadata : IModuleMetadata
             {
                 public string Name { get; set; }
@@ -117,6 +143,14 @@ namespace ScriptCs.Hosting.Tests
                 public string Extensions { get; set; }
 
                 public bool Autoload { get; set; }
+            }
+
+            public class DummyModule : IModule
+            {
+                public void Initialize(IModuleConfiguration config)
+                {
+                    config.Overrides[typeof (string)] = "module loaded";
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #964 

Great perf benefit - improves startup from ~1.5s to ~0.5s.

Tested on Win and OS X