### PR TITLE
fix nightly package dependencies

### DIFF
--- a/build/ScriptCs.Version.props
+++ b/build/ScriptCs.Version.props
@@ -17,9 +17,9 @@
     <AssemblyVersion>$(MajorVersion).$(MinorVersion).0</AssemblyVersion>
     <AssemblyInformationalVersion>$(MajorVersion).$(MinorVersion).$(PatchVersion)</AssemblyInformationalVersion>
     <AssemblyInformationalVersion Condition=" '$(BuildQuality)' != '' ">$(AssemblyInformationalVersion)-$(BuildQuality)</AssemblyInformationalVersion>
+    <AssemblyInformationalVersion Condition=" '$(IsNightlyBuild)' != '' ">$(AssemblyInformationalVersion)-nightly-$([System.DateTime]::UtcNow.ToString("yyMMdd"))</AssemblyInformationalVersion>
 
     <PackageVersion>$(AssemblyInformationalVersion)</PackageVersion>
-    <PackageVersion Condition=" '$(IsNightlyBuild)' != '' ">$(PackageVersion)-nightly-$([System.DateTime]::UtcNow.ToString("yyMMdd"))</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes #978 

Also has a nice side effect:

![image](https://cloud.githubusercontent.com/assets/677704/6766143/937e97a0-cffa-11e4-99ba-e8976733f58b.png)

Previously, only `0.14.0` would be shown here.