### PR TITLE
Only use fast path when extension is CSX or none

### DIFF
--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -72,7 +72,7 @@ namespace ScriptCs.Hosting
             if (modulePackagesPaths == null) return;
 
             // only CSharp module needed - use fast path
-            if (moduleNames.Length == 1 && DefaultCSharpModules.ContainsKey(moduleNames[0]) && (extension == DefaultCSharpExtension || string.IsNullOrWhiteSpace(extension))) 
+            if (moduleNames.Length == 1 && DefaultCSharpModules.ContainsKey(moduleNames[0]) && (string.IsNullOrWhiteSpace(extension) || extension.Equals(DefaultCSharpExtension, StringComparison.InvariantCultureIgnoreCase))) 
             {
                 _logger.Debug("Only CSharp module is needed - will skip module lookup");
                 var csharpModuleAssembly = DefaultCSharpModules[moduleNames[0]];

--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -18,6 +18,8 @@ namespace ScriptCs.Hosting
             {"mono", "ScriptCs.Engine.Mono.dll"}
         };
 
+        internal static readonly string DefaultCSharpExtension = ".csx";
+
         private readonly IAssemblyResolver _resolver;
         private readonly ILog _logger;
         private readonly Action<Assembly, AggregateCatalog> _addToCatalog;
@@ -69,7 +71,8 @@ namespace ScriptCs.Hosting
         {
             if (modulePackagesPaths == null) return;
 
-            if (moduleNames.Length == 1 && DefaultCSharpModules.ContainsKey(moduleNames[0])) // only CSharp module needed
+            // only CSharp module needed - use fast path
+            if (moduleNames.Length == 1 && DefaultCSharpModules.ContainsKey(moduleNames[0]) && (extension == DefaultCSharpExtension || string.IsNullOrWhiteSpace(extension))) 
             {
                 _logger.Debug("Only CSharp module is needed - will skip module lookup");
                 var csharpModuleAssembly = DefaultCSharpModules[moduleNames[0]];

--- a/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ModuleLoaderTests.cs
@@ -117,7 +117,7 @@ namespace ScriptCs.Hosting.Tests
                 var path = Path.Combine("c:\\foo", ModuleLoader.DefaultCSharpModules["roslyn"]);
                 _mockAssemblyUtility.Setup(x => x.LoadFile(path));
                 var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (a, c) => { }, _getModules, _mockFileSystem.Object, _mockAssemblyUtility.Object);
-                loader.Load(null, new string[0], "c:\\foo", null, "roslyn");
+                loader.Load(null, new string[0], "c:\\foo", ModuleLoader.DefaultCSharpExtension, "roslyn");
 
                 _mockAssemblyUtility.Verify(x => x.LoadFile(path), Times.Once());
             }
@@ -130,9 +130,20 @@ namespace ScriptCs.Hosting.Tests
 
                 var config = new ModuleConfiguration(true, string.Empty, false, LogLevel.Debug, true,
                     new Dictionary<Type, object> {{typeof (string), "not loaded"}});
-                loader.Load(config, new string[0], "c:\\foo", null, "roslyn");
+                loader.Load(config, new string[0], "c:\\foo", ModuleLoader.DefaultCSharpExtension, "roslyn");
 
                 config.Overrides[typeof(string)].ShouldEqual("module loaded");
+            }
+
+            [Fact]
+            public void ShouldNotLoadEngineAssemblyByHandIfItsTheOnlyModuleButExtensionIsNotDefault()
+            {
+                var path = Path.Combine("c:\\foo", ModuleLoader.DefaultCSharpModules["roslyn"]);
+                _mockAssemblyUtility.Setup(x => x.LoadFile(path));
+                var loader = new ModuleLoader(_mockAssemblyResolver.Object, _mockLogger.Object, (a, c) => { }, _getModules, _mockFileSystem.Object, _mockAssemblyUtility.Object);
+                
+                loader.Load(null, new string[0], "c:\\foo", ".fsx", "roslyn");
+                _mockAssemblyUtility.Verify(x => x.LoadFile(It.IsAny<string>()), Times.Never);
             }
 
             public class ModuleMetadata : IModuleMetadata


### PR DESCRIPTION
Fixes #964 and unblocks 0.14 release

The fast path is only invoked if there is:

 - no explicit module provided AND
 - file extension is "csx" OR no extension (REPL mode)