### PR TITLE
change version from 0.14 to 0.15

### DIFF
--- a/build/ScriptCs.Version.props
+++ b/build/ScriptCs.Version.props
@@ -4,7 +4,7 @@
   <!-- Use the properties below to control the version of the assemblies created. -->
   <PropertyGroup>
     <MajorVersion>0</MajorVersion>
-    <MinorVersion>14</MinorVersion>
+    <MinorVersion>15</MinorVersion>
     <PatchVersion>0</PatchVersion>
 
     <!-- Change this to set the build quality of the project. Use values like "alpha", "beta", "rc1", "rtm", etc. -->


### PR DESCRIPTION
re #947

We need to start doing this immediately after each release, otherwise it's impossible for a consuming project which is currently using our 0.14 NuGet packages to update to our nightly NuGet packages.