### PR TITLE
change PackageAssemblyResolver to warn when packages directory does not exist

### DIFF
--- a/src/ScriptCs.Core/PackageAssemblyResolver.cs
+++ b/src/ScriptCs.Core/PackageAssemblyResolver.cs
@@ -37,7 +37,7 @@ namespace ScriptCs
             var packagesFolder = Path.Combine(_fileSystem.CurrentDirectory, _fileSystem.PackagesFolder);
             if (!_fileSystem.DirectoryExists(packagesFolder))
             {
-                _logger.Info("Packages directory does not exist!");
+                _logger.Warn("Packages directory does not exist!");
                 return;
             }
 

--- a/test/ScriptCs.Core.Tests/PackageAssemblyResolverTests.cs
+++ b/test/ScriptCs.Core.Tests/PackageAssemblyResolverTests.cs
@@ -370,7 +370,7 @@ namespace ScriptCs.Tests
                 resolver.SavePackages();
 
                 _pc.Verify(i => i.CreatePackageFile(), Times.Never());
-                _log.Output.ShouldContain("Packages directory does not exist!");
+                _log.Output.ShouldContain("WARN: Packages directory does not exist!");
             }
 
             [Fact]


### PR DESCRIPTION
noticed when implementing https://github.com/scriptcs/scriptcs/issues/847