### PR TITLE
Support for namespace aliasing

### DIFF
--- a/src/ScriptCs.Core/UsingLineProcessor.cs
+++ b/src/ScriptCs.Core/UsingLineProcessor.cs
@@ -30,7 +30,7 @@ namespace ScriptCs
 
         private static bool IsUsingLine(string line)
         {
-            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";");
+            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";") && !line.Contains("=");
         }
 
         private static string GetNamespace(string line)

--- a/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
@@ -37,6 +37,19 @@ namespace ScriptCs.Tests
             }
 
             [Theory, ScriptCsAutoData]
+            public void ShouldIgnoreAliases(IFileParser parser, UsingLineProcessor processor)
+            {
+                // Arrange
+                const string UsingLine = @"using Path = ""System.IO.Path"";";
+
+                // Act
+                var result = processor.ProcessLine(parser, new FileParserContext(), UsingLine, true);
+
+                // Assert
+                result.ShouldBeFalse();
+            }
+
+            [Theory, ScriptCsAutoData]
             public void ShouldAddNamespaceToContext(IFileParser parser, UsingLineProcessor processor)
             {
                 // Arrange


### PR DESCRIPTION
Currently we don't allow namespace aliasing - this PR fixes it.

Fixes #826 