### PR TITLE
Added :scriptpacks REPL command

### DIFF
--- a/src/ScriptCs.Contracts/ScriptPackSession.cs
+++ b/src/ScriptCs.Contracts/ScriptPackSession.cs
@@ -37,7 +37,7 @@ namespace ScriptCs.Contracts
             }
         }
 
-        public IEnumerable<IScriptPackContext> Contexts
+        public virtual IEnumerable<IScriptPackContext> Contexts
         {
             get { return _contexts; }
         }

--- a/src/ScriptCs.Core/Extensions/EnumerableExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace ScriptCs.Extensions
+{
+    internal static class EnumerableExtensions
+    {
+        internal static bool IsNullOrEmpty<T>(this IEnumerable<T> enumerable)
+        {
+            if (enumerable == null)
+            {
+                return true;
+            }
+
+            var collection = enumerable as ICollection<T>;
+            if (collection != null)
+            {
+                return collection.Count == 0;
+            }
+
+            return !enumerable.Any();
+        }
+    }
+}

--- a/src/ScriptCs.Core/Extensions/MethodInfoExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/MethodInfoExtensions.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace ScriptCs.Extensions
+{
+    internal static class MethodInfoExtensions
+    {
+        internal static IEnumerable<ParameterInfo> GetParametersWithoutExtensions(this MethodInfo method)
+        {
+            IEnumerable<ParameterInfo> methodParams = method.GetParameters();
+            if (method.IsDefined(typeof(ExtensionAttribute), false))
+            {
+                methodParams = methodParams.Skip(1);
+            }
+
+            return methodParams;
+        }
+    }
+}

--- a/src/ScriptCs.Core/Extensions/TypeExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/TypeExtensions.cs
@@ -10,7 +10,7 @@ namespace ScriptCs.Extensions
     {
         internal static IEnumerable<MethodInfo> GetExtensionMethods(this Type type)
         {
-            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
+            return AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes()).Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
                 SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
                 Where(x => x.GetParameters()[0].ParameterType == type);
         }  

--- a/src/ScriptCs.Core/Extensions/TypeExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/TypeExtensions.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+
+namespace ScriptCs.Extensions
+{
+    internal static class TypeExtensions
+    {
+        internal static IEnumerable<MethodInfo> GetExtensionMethods(this Type type)
+        {
+            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
+                SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
+                Where(x => x.GetParameters()[0].ParameterType == type);
+        }  
+    }
+}

--- a/src/ScriptCs.Core/Extensions/TypeExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/TypeExtensions.cs
@@ -13,6 +13,12 @@ namespace ScriptCs.Extensions
             return AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes()).Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
                 SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
                 Where(x => x.GetParameters()[0].ParameterType == type);
+        }
+
+        internal static IEnumerable<MethodInfo> GetAllMethods(this Type type)
+        {
+            return type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).
+                    Where(m => !m.IsSpecialName).Union(type.GetExtensionMethods()).OrderBy(x => x.Name);
         }  
     }
 }

--- a/src/ScriptCs.Core/Extensions/TypeExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/TypeExtensions.cs
@@ -10,7 +10,7 @@ namespace ScriptCs.Extensions
     {
         internal static IEnumerable<MethodInfo> GetExtensionMethods(this Type type)
         {
-            return AppDomain.CurrentDomain.GetAssemblies().SelectMany(x => x.GetTypes()).Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
+            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
                 SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
                 Where(x => x.GetParameters()[0].ParameterType == type);
         }

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -44,8 +44,7 @@ namespace ScriptCs.ReplCommands
                 var contextType = packContext.GetType();
                 _console.WriteLine(contextType.ToString());
 
-                var methods = contextType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).
-                    Where(m => !m.IsSpecialName).Union(contextType.GetExtensionMethods()).OrderBy(x => x.Name);
+                var methods = contextType.GetAllMethods();
                 var properties = contextType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
 
                 PrintMethods(methods, importedNamespaces);
@@ -59,7 +58,7 @@ namespace ScriptCs.ReplCommands
 
         private void PrintMethods(IEnumerable<MethodInfo> methods, string[] importedNamespaces)
         {
-            if (methods.Any())
+            if (!methods.IsNullOrEmpty())
             {
                 _console.WriteLine("** Methods **");
                 foreach (var method in methods)
@@ -77,7 +76,7 @@ namespace ScriptCs.ReplCommands
 
         private void PrintProperties(IEnumerable<PropertyInfo> properties, string[] importedNamespaces)
         {
-            if (properties.Any())
+            if (!properties.IsNullOrEmpty())
             {
                 _console.WriteLine("** Properties **");
                 foreach (var property in properties)

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -1,0 +1,22 @@
+﻿using ScriptCs.Contracts;
+
+namespace ScriptCs.ReplCommands
+{
+    public class ScriptPacksCommand : IReplCommand
+    {
+        public string Description
+        {
+            get { return "Displays information about script packs available in the REPL session"; }
+        }
+
+        public string CommandName
+        {
+            get { return "scriptpacks"; }
+        }
+
+        public object Execute(IRepl repl, object[] args)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -30,13 +30,10 @@ namespace ScriptCs.ReplCommands
         public object Execute(IRepl repl, object[] args)
         {
             var packContexts = repl.ScriptPackSession.Contexts;
-            var originalColor = _console.ForegroundColor;
-            _console.ForegroundColor = ConsoleColor.Yellow;
 
             if (packContexts.IsNullOrEmpty())
             {
-                _console.WriteLine("There are no script packs available in this REPL session");
-                _console.ForegroundColor = originalColor;
+                PrintInColor("There are no script packs available in this REPL session");
                 return null;
             }
 
@@ -45,9 +42,7 @@ namespace ScriptCs.ReplCommands
             foreach (var packContext in packContexts)
             {
                 var contextType = packContext.GetType();
-                
-                _console.WriteLine(contextType.ToString());
-                _console.ForegroundColor = originalColor;
+                PrintInColor(contextType.ToString());
 
                 var methods = contextType.GetAllMethods();
                 var properties = contextType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
@@ -59,6 +54,14 @@ namespace ScriptCs.ReplCommands
             }
 
             return null;
+        }
+
+        private void PrintInColor(string text)
+        {
+            var originalColor = _console.ForegroundColor;
+            _console.ForegroundColor = ConsoleColor.Yellow;
+            _console.WriteLine(text);
+            _console.ForegroundColor = originalColor;
         }
 
         private void PrintMethods(IEnumerable<MethodInfo> methods, string[] importedNamespaces)

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text;
 using ScriptCs.Contracts;
 using ScriptCs.Extensions;
@@ -38,11 +37,15 @@ namespace ScriptCs.ReplCommands
             }
 
             var importedNamespaces = repl.Namespaces.Union(repl.ScriptPackSession.Namespaces).ToArray();
+            var originalColor = _console.ForegroundColor;
 
             foreach (var packContext in packContexts)
             {
                 var contextType = packContext.GetType();
+
+                _console.ForegroundColor = ConsoleColor.Yellow;
                 _console.WriteLine(contextType.ToString());
+                _console.ForegroundColor = originalColor;
 
                 var methods = contextType.GetAllMethods();
                 var properties = contextType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -40,7 +40,7 @@ namespace ScriptCs.ReplCommands
                 return null;
             }
 
-            var importedNamespaces = repl.Namespaces.Union(repl.ScriptPackSession.Namespaces).ToArray();
+            var importedNamespaces = repl.ScriptPackSession.Namespaces.IsNullOrEmpty() ? repl.Namespaces.ToArray() : repl.Namespaces.Union(repl.ScriptPackSession.Namespaces).ToArray();
 
             foreach (var packContext in packContexts)
             {
@@ -86,8 +86,22 @@ namespace ScriptCs.ReplCommands
                 _console.WriteLine("** Properties **");
                 foreach (var property in properties)
                 {
-                    var signature = string.Format(" - {0} {1}", GetPrintableType(property.PropertyType, importedNamespaces), property.Name);
-                    _console.WriteLine(signature);
+                    var propertyBuilder = new StringBuilder(string.Format(" - {0} {1}", GetPrintableType(property.PropertyType, importedNamespaces), property.Name));
+                    propertyBuilder.Append(" {");
+
+                    if (property.GetGetMethod() != null)
+                    {
+                        propertyBuilder.Append(" get;");
+                    }
+
+                    if (property.GetSetMethod() != null)
+                    {
+                        propertyBuilder.Append(" set;");
+                    }
+
+                    propertyBuilder.Append(" }");
+
+                    _console.WriteLine(propertyBuilder.ToString());
                 }
             }
         }

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -30,20 +30,22 @@ namespace ScriptCs.ReplCommands
         public object Execute(IRepl repl, object[] args)
         {
             var packContexts = repl.ScriptPackSession.Contexts;
+            var originalColor = _console.ForegroundColor;
+            _console.ForegroundColor = ConsoleColor.Yellow;
+
             if (packContexts.IsNullOrEmpty())
             {
                 _console.WriteLine("There are no script packs available in this REPL session");
+                _console.ForegroundColor = originalColor;
                 return null;
             }
 
             var importedNamespaces = repl.Namespaces.Union(repl.ScriptPackSession.Namespaces).ToArray();
-            var originalColor = _console.ForegroundColor;
 
             foreach (var packContext in packContexts)
             {
                 var contextType = packContext.GetType();
-
-                _console.ForegroundColor = ConsoleColor.Yellow;
+                
                 _console.WriteLine(contextType.ToString());
                 _console.ForegroundColor = originalColor;
 

--- a/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ScriptPacksCommand.cs
@@ -1,9 +1,22 @@
-﻿using ScriptCs.Contracts;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using ScriptCs.Contracts;
 
 namespace ScriptCs.ReplCommands
 {
     public class ScriptPacksCommand : IReplCommand
     {
+        private readonly IConsole _console;
+
+        public ScriptPacksCommand(IConsole console)
+        {
+            _console = console;
+        }
+
         public string Description
         {
             get { return "Displays information about script packs available in the REPL session"; }
@@ -16,7 +29,144 @@ namespace ScriptCs.ReplCommands
 
         public object Execute(IRepl repl, object[] args)
         {
-            throw new System.NotImplementedException();
+            var packContexts = repl.ScriptPackSession.Contexts;
+
+            if (packContexts == null || !packContexts.Any())
+            {
+                _console.WriteLine("There are no script packs available in this REPL session");
+                return null;
+            }
+
+            var importedNamespaces = repl.Namespaces.Union(repl.ScriptPackSession.Namespaces).ToArray();
+
+            foreach (var packContext in packContexts)
+            {
+                var contextType = packContext.GetType();
+                _console.WriteLine(contextType.ToString());
+
+                var methods = contextType.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).
+                    Where(m => !m.IsSpecialName).Union(GetExtensionMethods(contextType)).OrderBy(x => x.Name);
+                var properties = contextType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+
+                if (methods.Any())
+                {
+                    _console.WriteLine("** Methods **");
+                    foreach (var method in methods)
+                    {
+                        var methodParams =
+                            method.GetParameters().Select(p => string.Format("{0} {1}", GetPrintableType(p.ParameterType, importedNamespaces), p.Name));
+
+                        if (method.IsDefined(typeof(ExtensionAttribute), false))
+                        {
+                            methodParams = methodParams.Skip(1);
+                        }
+
+                        var signature = string.Format(" - {0} {1}({2})", GetPrintableType(method.ReturnType, importedNamespaces), method.Name,
+                            string.Join(", ", methodParams));
+                        _console.WriteLine(signature);
+                    }
+                    _console.WriteLine();
+                }
+
+                if (properties.Any())
+                {
+                    _console.WriteLine("** Properties **");
+                    foreach (var property in properties)
+                    {
+                        var signature = string.Format(" - {0} {1}", GetPrintableType(property.PropertyType, importedNamespaces), property.Name);
+                        _console.WriteLine(signature);
+                    }
+                }
+
+                _console.WriteLine();
+            }
+
+            return null;
+        }
+
+        private string GetPrintableType(Type type, string[] importedNamespaces)
+        {
+            if (type.Name == "Void")
+            {
+                return "void";
+            }
+
+            if (type.Name == "Object")
+            {
+                return "object";
+            }
+
+            if (type.IsGenericType)
+            {
+                return BuildGeneric(type, importedNamespaces);
+            }
+
+            var nullableType = Nullable.GetUnderlyingType(type);
+            if (nullableType != null)
+            {
+                return string.Format("{0}?", GetPrintableType(nullableType, importedNamespaces));
+            }
+
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Boolean:
+                    return "bool";
+                case TypeCode.Byte:
+                    return "byte";
+                case TypeCode.Char:
+                    return "char";
+                case TypeCode.Decimal:
+                    return "decimal";
+                case TypeCode.Double:
+                    return "double";
+                case TypeCode.Int16:
+                    return "short";
+                case TypeCode.Int32:
+                    return "int";
+                case TypeCode.Int64:
+                    return "long";
+                case TypeCode.SByte:
+                    return "sbyte";
+                case TypeCode.Single:
+                    return "Single";
+                case TypeCode.String:
+                    return "string";
+                case TypeCode.UInt16:
+                    return "UInt16";
+                case TypeCode.UInt32:
+                    return "UInt32";
+                case TypeCode.UInt64:
+                    return "UInt64";
+                default:
+                    return string.IsNullOrEmpty(type.FullName) || importedNamespaces.Contains(type.Namespace)
+                        ? type.Name
+                        : type.FullName;
+            }
+        }
+
+        private string BuildGeneric(Type type, string[] importedNamespaces)
+        {
+            var baseName = type.Name.Substring(0, type.Name.IndexOf("`", StringComparison.Ordinal));
+            var genericDefinition = new StringBuilder(string.Format("{0}<", baseName));
+            var firstArgument = true;
+            foreach (var t in type.GetGenericArguments())
+            {
+                if (!firstArgument)
+                {
+                    genericDefinition.Append(", ");
+                }
+                genericDefinition.Append(GetPrintableType(t, importedNamespaces));
+                firstArgument = false;
+            }
+            genericDefinition.Append(">");
+            return genericDefinition.ToString();
+        }
+
+        private static IEnumerable<MethodInfo> GetExtensionMethods(Type type)
+        {
+            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
+                SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
+                Where(x => x.GetParameters()[0].ParameterType == type);
         }
     }
 }

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -52,6 +52,7 @@
     <Compile Include="AssemblyUtility.cs" />
     <Compile Include="FileSystemMigrator.cs" />
     <Compile Include="NullScriptLibraryComposer.cs" />
+    <Compile Include="ReplCommands\ScriptPacksCommand.cs" />
     <Compile Include="ScriptLibraryComposer.cs" />
     <Compile Include="ScriptLibraryWrapper.cs" />
     <Compile Include="ReplCommands\AliasCommand.cs" />

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -50,6 +50,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="AssemblyUtility.cs" />
+    <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="FileSystemMigrator.cs" />
     <Compile Include="NullScriptLibraryComposer.cs" />

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -50,9 +50,11 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="AssemblyUtility.cs" />
+    <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="FileSystemMigrator.cs" />
     <Compile Include="NullScriptLibraryComposer.cs" />
     <Compile Include="ReplCommands\ScriptPacksCommand.cs" />
+    <Compile Include="Extensions\TypeExtensions.cs" />
     <Compile Include="ScriptLibraryComposer.cs" />
     <Compile Include="ScriptLibraryWrapper.cs" />
     <Compile Include="ReplCommands\AliasCommand.cs" />

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -33,7 +33,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\..\..\..\test3\</OutputPath>
+    <OutputPath>bin\debug\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -33,7 +33,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\..\..\..\..\..\test3\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/test/ScriptCs.Core.Tests/ReplCommands/ScriptPacksCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ScriptPacksCommandTests.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Moq;
+using ScriptCs.Contracts;
+using ScriptCs.ReplCommands;
+using Xunit;
+
+namespace ScriptCs.Tests.ReplCommands
+{
+    public class ScriptPacksCommandTests
+    {
+        public class CommandNameProperty
+        {
+            [Fact]
+            public void ReturnsScriptPacks()
+            {
+                // act
+                var cmd = new ScriptPacksCommand(new Mock<IConsole>().Object);
+
+                // assert
+                Assert.Equal("scriptpacks", cmd.CommandName);
+            }
+        }
+
+        public class ExecuteMethod
+        {
+            [Fact]
+            public void ShouldExitIfThereAreNoScriptPacks()
+            {
+                // arrange
+                var console = new Mock<IConsole>();
+                var repl = new Mock<IRepl>();
+                var scriptPackSession = new Mock<ScriptPackSession>(Enumerable.Empty<IScriptPack>(), new string[0]);
+
+                scriptPackSession.Setup(x => x.Contexts).Returns((IEnumerable<IScriptPackContext>) null);
+                repl.Setup(x => x.ScriptPackSession).Returns(scriptPackSession.Object);
+
+                var cmd = new ScriptPacksCommand(console.Object);
+
+                // act
+                cmd.Execute(repl.Object, null);
+
+                // assert
+                console.Verify(x => x.WriteLine("There are no script packs available in this REPL session"));
+            }
+        }
+    }
+}

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="FileSystemMigratorTests.cs" />
     <Compile Include="PackageReferenceTests.cs" />
     <Compile Include="ReplCommands\HelpCommandTests.cs" />
+    <Compile Include="ReplCommands\ScriptPacksCommandTests.cs" />
     <Compile Include="ScriptLibraryComposerTests.cs" />
     <Compile Include="ReferenceLineProcessorTests.cs" />
     <Compile Include="LoadLineProcessorTests.cs" />


### PR DESCRIPTION
Allows to easily inspect the script packs available in the REPL context.

 - prints method signatures (including extension methods)
 - prints property definitions (including correct getter/setter)
 - uses fully qualified type names if the given namespace is not imported into REPL context, if it is imported uses simple type name

Example:
![screenshot 2015-03-28 23 31 51](https://cloud.githubusercontent.com/assets/1710369/6883202/e2212a6e-d5a2-11e4-801e-b9bc6df148a0.png)
