### PR TITLE
Add null checks to AppDomainAssemblyResolver constructor

### DIFF
--- a/src/ScriptCs.Core/AppDomainAssemblyResolver.cs
+++ b/src/ScriptCs.Core/AppDomainAssemblyResolver.cs
@@ -23,6 +23,11 @@ namespace ScriptCs
             IDictionary<string, AssemblyInfo> assemblyInfoMap = null,
             Func<object, ResolveEventArgs, Assembly> resolveHandler = null)
         {
+            Guard.AgainstNullArgument("logger", logger);
+            Guard.AgainstNullArgument("fileSystem", fileSystem);
+            Guard.AgainstNullArgument("resolver", resolver);
+            Guard.AgainstNullArgument("assemblyUtility", assemblyUtility);
+
             _assemblyInfoMap = assemblyInfoMap ?? new Dictionary<string, AssemblyInfo>();
             _assemblyUtility = assemblyUtility;
             _logger = logger;


### PR DESCRIPTION
Hello,  I thought you might like to add null checks to the arguments of this constructor.

FYI, I found these missing checks with a static analysis tool I'm working on based on CodeContracts and Roslyn.  I can run it over the whole repo and provide the full output if you're interested.  If you're interested in running the tool yourself, it is open source and on github.  I'll be making the repo public soon. Thanks!