### PR TITLE
Add missing null checks found by static analysis

### DIFF
--- a/src/ScriptCs.Core/FilePreProcessor.cs
+++ b/src/ScriptCs.Core/FilePreProcessor.cs
@@ -17,6 +17,9 @@ namespace ScriptCs
 
         public FilePreProcessor(IFileSystem fileSystem, ILog logger, IEnumerable<ILineProcessor> lineProcessors)
         {
+            Guard.AgainstNullArgument("fileSystem", fileSystem);
+            Guard.AgainstNullArgument("logger", logger);
+
             _fileSystem = fileSystem;
             _logger = logger;
             _lineProcessors = lineProcessors;

--- a/src/ScriptCs.Core/LoadLineProcessor.cs
+++ b/src/ScriptCs.Core/LoadLineProcessor.cs
@@ -14,6 +14,8 @@ namespace ScriptCs
 
         public LoadLineProcessor(IFileSystem fileSystem)
         {
+            Guard.AgainstNullArgument("fileSystem", fileSystem);
+
             _fileSystem = fileSystem;
         }
 

--- a/src/ScriptCs.Core/ReferenceLineProcessor.cs
+++ b/src/ScriptCs.Core/ReferenceLineProcessor.cs
@@ -14,6 +14,8 @@ namespace ScriptCs
 
         public ReferenceLineProcessor(IFileSystem fileSystem)
         {
+            Guard.AgainstNullArgument("fileSystem", fileSystem);
+
             _fileSystem = fileSystem;
         }
 

--- a/src/ScriptCs.Core/ReplCommands/AliasCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/AliasCommand.cs
@@ -12,6 +12,8 @@ namespace ScriptCs.ReplCommands
 
         public AliasCommand(IConsole console)
         {
+            Guard.AgainstNullArgument("console", console);
+            
             _console = console;
         }
 

--- a/src/ScriptCs.Core/ReplCommands/ExitCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/ExitCommand.cs
@@ -18,6 +18,8 @@ namespace ScriptCs.ReplCommands
 
         public ExitCommand(IConsole console)
         {
+            Guard.AgainstNullArgument("console", console);
+
             _console = console;
         }
 

--- a/src/ScriptCs.Core/ReplCommands/HelpCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/HelpCommand.cs
@@ -9,6 +9,8 @@ namespace ScriptCs.ReplCommands
 
         public HelpCommand(IConsole console)
         {
+            Guard.AgainstNullArgument("console", console);
+
             _console = console;
         }
 


### PR DESCRIPTION
Hi, these are some more missing null checks my static analyzer found.

Note: the analyzer didn't suggest a null check for lineProcessors in FilePreProcessor.  I'm not sure why.  I can add it if you want.