### PR TITLE
convenience method on ScriptServicesBuilder

### DIFF
--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.Linq;
+using System.Collections.Generic;
 using ScriptCs.Contracts;
 using ScriptCs.Logging;
 using LogLevel = ScriptCs.Contracts.LogLevel;
 
 namespace ScriptCs.Hosting
 {
+
     public class ScriptServicesBuilder : ServiceOverrides<IScriptServicesBuilder>, IScriptServicesBuilder
     {
         private readonly ITypeResolver _typeResolver;
@@ -128,6 +130,12 @@ namespace ScriptCs.Hosting
         public IScriptServicesBuilder Debug(bool debug = true)
         {
             _debug = debug;
+            return this;
+        }
+
+        public IScriptServicesBuilder SetOverrides(Action<IDictionary<Type, object>> applyOverrides)
+        {
+            applyOverrides(Overrides);
             return this;
         }
 

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -85,14 +85,14 @@ namespace ScriptCs.Hosting
                 ? "mono"
                 : "roslyn";
 
-            moduleNames = moduleNames.Union(new[] {engineModule}).ToArray();
+            moduleNames = moduleNames.Union(new[] { engineModule }).ToArray();
 
             var config = new ModuleConfiguration(_cache, _scriptName, _repl, _logLevel, _debug, Overrides);
             var loader = InitializationServices.GetModuleLoader();
 
             var fs = InitializationServices.GetFileSystem();
 
-            var folders = new[] {fs.GlobalFolder};
+            var folders = new[] { fs.GlobalFolder };
             loader.Load(config, folders, InitializationServices.GetFileSystem().HostBin, extension, moduleNames);
             return this;
         }
@@ -133,9 +133,15 @@ namespace ScriptCs.Hosting
             return this;
         }
 
-        public IScriptServicesBuilder SetOverrides(Action<IDictionary<Type, object>> applyOverrides)
+        public IScriptServicesBuilder SetOverride<TKey, TValue>(TValue value) where TValue : TKey
         {
-            applyOverrides(Overrides);
+            Overrides[typeof(TKey)] = value;
+            return this;
+        }
+
+        public IScriptServicesBuilder SetOverride<TKey, TValue>() where TValue : TKey
+        {
+            Overrides[typeof(TKey)] = typeof(TValue);
             return this;
         }
 

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -133,15 +133,15 @@ namespace ScriptCs.Hosting
             return this;
         }
 
-        public IScriptServicesBuilder SetOverride<TKey, TValue>(TValue value) where TValue : TKey
+        public IScriptServicesBuilder SetOverride<TContract, TImpl>(TImpl value) where TImpl : TContract
         {
-            Overrides[typeof(TKey)] = value;
+            Overrides[typeof(TContract)] = value;
             return this;
         }
 
-        public IScriptServicesBuilder SetOverride<TKey, TValue>() where TValue : TKey
+        public IScriptServicesBuilder SetOverride<TContract, TImpl>() where TImpl : TContract
         {
-            Overrides[typeof(TKey)] = typeof(TValue);
+            Overrides[typeof(TContract)] = typeof(TImpl);
             return this;
         }
 

--- a/test/ScriptCs.Hosting.Tests/ScriptServicesBuilderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ScriptServicesBuilderTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Moq;
 using Ploeh.AutoFixture.Xunit;
@@ -130,6 +131,59 @@ namespace ScriptCs.Hosting.Tests
                        });
 
             }
+        }
+
+        public class TheSetOverrideMethods
+        {
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnTheBuilder(ScriptServicesBuilder builder)
+            {
+                var someValue = new SomeOverride();
+                var returnedBuilder = builder.SetOverride<ISomeOverride, SomeOverride>(someValue);
+
+                returnedBuilder.ShouldBeSameAs(builder);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldSetTheValueUsingTheKey(ScriptServicesBuilder builder)
+            {
+                var someValue = new SomeOverride();
+                var key = typeof(ISomeOverride);
+                builder.SetOverride<ISomeOverride, SomeOverride>(someValue);
+
+                var overrides = builder.Overrides;
+                overrides.ContainsKey(key).ShouldBeTrue();
+                overrides[key].ShouldBeSameAs(someValue);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReplaceTheValueWhenKeyAlreadyExists(ScriptServicesBuilder builder)
+            {
+                var key = typeof(ISomeOverride);
+                var firstValue = new SomeOverride();
+                var secondValue = new SomeOverride();
+
+                builder.SetOverride<ISomeOverride, SomeOverride>(firstValue);
+                builder.SetOverride<ISomeOverride, SomeOverride>(secondValue);
+
+                var overrides = builder.Overrides;
+                overrides[key].ShouldNotBeSameAs(firstValue);
+                overrides[key].ShouldBeSameAs(secondValue);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldUseTheValueTypeWhenNoInstanceIsProvided(ScriptServicesBuilder builder)
+            {
+                var key = typeof(ISomeOverride);
+                builder.SetOverride<ISomeOverride, SomeOverride>();
+
+                var overrides = builder.Overrides;
+                overrides.ContainsKey(key).ShouldBeTrue();
+                overrides[key].ShouldBeSameAs(typeof(SomeOverride));
+            }
+
+            public interface ISomeOverride { }
+            public class SomeOverride : ISomeOverride { }
         }
     }
 }


### PR DESCRIPTION
I noticed that most of the fluent methods for `ScriptServicesBuilder` didn't have unit tests.
If you prefer for this to have them, just say so. :kissing_cat: 