### PR TITLE
Add rest of the missing null checks (that I could find)

### DIFF
--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -26,6 +26,9 @@ namespace ScriptCs
             IEnumerable<IReplCommand> replCommands)
             : base(fileSystem, filePreProcessor, scriptEngine, logger, composer)
         {
+            Guard.AgainstNullArgument("console", console);
+            Guard.AgainstNullArgument("serializer", serializer);
+            
             _scriptArgs = scriptArgs;
             _serializer = serializer;
             Console = console;

--- a/src/ScriptCs.Core/ScriptExecutorExtensions.cs
+++ b/src/ScriptCs.Core/ScriptExecutorExtensions.cs
@@ -21,6 +21,8 @@ namespace ScriptCs
 
         public static void ImportNamespace<T>(this IScriptExecutor executor)
         {
+            Guard.AgainstNullArgument("executor", executor);
+
             executor.ImportNamespaces(typeof(T));
         }
 
@@ -36,11 +38,15 @@ namespace ScriptCs
 
         public static void AddReference<T>(this IScriptExecutor executor)
         {
+            Guard.AgainstNullArgument("executor", executor);
+
             executor.AddReferences(typeof(T));
         }
 
         public static void AddReferenceAndImportNamespaces(this IScriptExecutor executor, Type[] types)
         {
+            Guard.AgainstNullArgument("executor", executor);
+
             executor.AddReferences(types);
             executor.ImportNamespaces(types);
         }


### PR DESCRIPTION
This is rest I could find except one (potentially).

When I was looking [here](https://github.com/scriptcs/scriptcs/blob/dev/src/ScriptCs.Core/Repl.cs#29) I thought it was weird that the tool didn't suggest a null check for _scriptArgs.  I don't know why exactly, but I believe it has something to do with the parameter scriptEngine being an interface type.  scriptArgs only ever gets passed as the second argument to ScriptEngine.Execute.  Since IScriptEngine is a public interface I can't know all the possible implementations of it, right?  So I can't know if the implementer will just dereference the null parameter or check for it.

I looked through the code for the implementers of IScriptEngine and its only inherited by another interface (IReplEngine).  IReplEngine is only implemented by MonoScriptEngine and RoslynReplEngine.  They both pass the second argument of Execute to the ScriptPackManager constructor which does check for null!  That was a very long-winded way of saying there is no missing null check for the implementers in the existing code, but a different implementer might not ... and this is an example of why finding all the missing null checks is pretty complicated :)