### PR TITLE
Set the global credential provider #1018

### DIFF
--- a/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
+++ b/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
@@ -55,6 +55,9 @@ namespace ScriptCs.Hosting.Package
             }
 
             var sourceProvider = new PackageSourceProvider(settings);
+
+            HttpClient.DefaultCredentialProvider = new SettingsCredentialProvider(NullCredentialProvider.Instance, sourceProvider);
+
             var sources = sourceProvider.LoadPackageSources().Where(i => i.IsEnabled == true);
 
             if (sources == null || !sources.Any())


### PR DESCRIPTION
Fix for #1018 that sets the global credential provider. This allows the NuGet HttpClient to use the credentials stored in NuGet.Config .

I tested this by editing my `%APPDATA%\NuGet\NuGet.Config` file to use `packageSourceCredentials` for our myget feeds, specifically our nuget mirror. This file has Username and Password credentials for some of the MyGet feeds and nuget.org is disabled using:

```xml
  <disabledPackageSources>
    <add key="https://www.nuget.org/api/v2/" value="true" />
  </disabledPackageSources>
```

I produced two builds using `build.cmd`, one from before the change and one from after and watched what they did using Fiddler. The build before the change would try the various feeds once and get a 401 response for each then just give up. The build after the change would retry with credentials following the 401 response getting 404s for most and a 200 for the package on the mirror feed. More importantly the build with the fix actually installed some packages too!

Regarding the approach, to my knowledge setting this global property is the only way to configure the NuGet HttpClient to use these credentials. It kind of makes me wonder if this should be fixed in NuGet.Core instead of here in script CS but I guess that is up to you all and those working on NuGet v2.

The location for this one line was chosen because of the proximity to the `PackageSourceProvider` instance. I would like to see this code in `Initialize` but I don't think setting it multiple times should hurt and I also don't see the `GetRepositorySources` method called anywhere except for `Initialize`.

Some things to note:

* No tests were created for this change. I really don't know a practical way to create a test for this change.
* The code that was edited does not appear to have any existing coverage (using NCrunch).
* I have no test failures before or after this change using `build.cmd`.