### PR TITLE
made Namespaces collection immutable and relevant methods virtual #1040

### DIFF
--- a/src/ScriptCs.Contracts/IScriptExecutor.cs
+++ b/src/ScriptCs.Contracts/IScriptExecutor.cs
@@ -7,7 +7,7 @@ namespace ScriptCs.Contracts
     {
         AssemblyReferences References { get; }
 
-        ICollection<string> Namespaces { get; }
+        IReadOnlyCollection<string> Namespaces { get; }
 
         IScriptEngine ScriptEngine { get; }
 

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -47,7 +47,7 @@ namespace ScriptCs
 
         public AssemblyReferences References { get; private set; }
 
-        public ICollection<string> Namespaces { get; private set; }
+        public IReadOnlyCollection<string> Namespaces { get; private set; }
 
         public ScriptPackSession ScriptPackSession { get; protected set; }
 
@@ -75,8 +75,7 @@ namespace ScriptCs
             Guard.AgainstNullArgument("composer", composer);
 
             References = new AssemblyReferences(DefaultReferences);
-            Namespaces = new Collection<string>();
-            ImportNamespaces(DefaultNamespaces);
+            Namespaces = new ReadOnlyCollection<string>(DefaultNamespaces);
             FileSystem = fileSystem;
             FilePreProcessor = filePreProcessor;
             ScriptEngine = scriptEngine;
@@ -84,24 +83,16 @@ namespace ScriptCs
             ScriptLibraryComposer = composer;
         }
 
-        public void ImportNamespaces(params string[] namespaces)
+        public virtual void ImportNamespaces(params string[] namespaces)
         {
             Guard.AgainstNullArgument("namespaces", namespaces);
-
-            foreach (var @namespace in namespaces)
-            {
-                Namespaces.Add(@namespace);
-            }
+            Namespaces = new ReadOnlyCollection<string>(Namespaces.Union(namespaces).ToArray());
         }
 
-        public void RemoveNamespaces(params string[] namespaces)
+        public virtual void RemoveNamespaces(params string[] namespaces)
         {
             Guard.AgainstNullArgument("namespaces", namespaces);
-
-            foreach (var @namespace in namespaces)
-            {
-                Namespaces.Remove(@namespace);
-            }
+            Namespaces = new ReadOnlyCollection<string>(Namespaces.Except(namespaces).ToArray());
         }
 
         public virtual void AddReferences(params Assembly[] assemblies)
@@ -151,9 +142,7 @@ namespace ScriptCs
         public virtual void Reset()
         {
             References = new AssemblyReferences(DefaultReferences);
-            Namespaces.Clear();
-            ImportNamespaces(DefaultNamespaces);
-
+            Namespaces = new ReadOnlyCollection<string>(DefaultNamespaces);
             ScriptPackSession.State.Clear();
         }
 


### PR DESCRIPTION
Small breaking change if people changed ```IScriptExecutor.Namespaces``` directly or kept a reference to it somewhere else (assuming it will be update when the namespaces change)