### PR TITLE
 Remove IReplCommand argument getting evaluated  

### DIFF
--- a/src/ScriptCs.Contracts/IConsole.cs
+++ b/src/ScriptCs.Contracts/IConsole.cs
@@ -19,5 +19,7 @@ namespace ScriptCs.Contracts
         void ResetColor();
 
         ConsoleColor ForegroundColor { get; set; }
+
+        int Width { get; }
     }
 }

--- a/src/ScriptCs.Core/App_Packages/LibLog.3.1/LibLog.cs
+++ b/src/ScriptCs.Core/App_Packages/LibLog.3.1/LibLog.cs
@@ -463,7 +463,7 @@ namespace ScriptCs.Logging
 #else
                 Console.WriteLine(
 #endif
-                    "Exception occurred resolving a log provider. Logging for this assembly {0} is disabled. {1}",
+                    "Exception occured resolving a log provider. Logging for this assembly {0} is disabled. {1}",
                     typeof(LogProvider).GetAssemblyPortable().FullName,
                     ex);
             }
@@ -1814,7 +1814,7 @@ namespace ScriptCs.Logging.LogProviders
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
         /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually 
-        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number. 
+        /// used. So, this class simulates that. it will replace any text in {curlybraces} with an index number. 
         /// 
         /// "Log {message} to {user}" would turn into => "Log {0} to {1}". Then the format parameters are handled using regular .net string.Format.
         /// </summary>

--- a/src/ScriptCs.Core/App_Packages/LibLog.3.1/LibLog.cs
+++ b/src/ScriptCs.Core/App_Packages/LibLog.3.1/LibLog.cs
@@ -463,7 +463,7 @@ namespace ScriptCs.Logging
 #else
                 Console.WriteLine(
 #endif
-                    "Exception occured resolving a log provider. Logging for this assembly {0} is disabled. {1}",
+                    "Exception occurred resolving a log provider. Logging for this assembly {0} is disabled. {1}",
                     typeof(LogProvider).GetAssemblyPortable().FullName,
                     ex);
             }
@@ -1814,7 +1814,7 @@ namespace ScriptCs.Logging.LogProviders
         /// <summary>
         /// Some logging frameworks support structured logging, such as serilog. This will allow you to add names to structured data in a format string:
         /// For example: Log("Log message to {user}", user). This only works with serilog, but as the user of LibLog, you don't know if serilog is actually 
-        /// used. So, this class simulates that. it will replace any text in {curlybraces} with an index number. 
+        /// used. So, this class simulates that. it will replace any text in {curly braces} with an index number. 
         /// 
         /// "Log {message} to {user}" would turn into => "Log {0} to {1}". Then the format parameters are handled using regular .net string.Format.
         /// </summary>

--- a/src/ScriptCs.Core/Extensions/TypeExtensions.cs
+++ b/src/ScriptCs.Core/Extensions/TypeExtensions.cs
@@ -10,15 +10,15 @@ namespace ScriptCs.Extensions
     {
         internal static IEnumerable<MethodInfo> GetExtensionMethods(this Type type)
         {
-            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed).
-                SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false)).
-                Where(x => x.GetParameters()[0].ParameterType == type);
+            return type.Assembly.GetExportedTypes().Where(x => !x.IsGenericType && !x.IsNested && x.IsSealed)
+                    .SelectMany(x => x.GetMethods(BindingFlags.Static | BindingFlags.Public)).Where(x => x.IsDefined(typeof(ExtensionAttribute), false))
+                    .Where(x => x.GetParameters()[0].ParameterType == type);
         }
 
         internal static IEnumerable<MethodInfo> GetAllMethods(this Type type)
         {
-            return type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly).
-                    Where(m => !m.IsSpecialName).Union(type.GetExtensionMethods()).OrderBy(x => x.Name);
+            return type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly)
+                    .Where(m => !m.IsSpecialName).Union(type.GetExtensionMethods()).OrderBy(x => x.Name);
         }  
     }
 }

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -65,34 +65,14 @@ namespace ScriptCs
                             var argsToPass = new List<object>();
                             foreach (var argument in tokens.Skip(1))
                             {
-                                var argumentResult = ScriptEngine.Execute(
-                                    argument, _scriptArgs, References, Namespaces, ScriptPackSession);
-
-                                if (argumentResult.CompileExceptionInfo != null)
-                                {
-                                    throw new Exception(
-                                        GetInvalidCommandArgumentMessage(argument),
-                                        argumentResult.CompileExceptionInfo.SourceException);
-                                }
-
-                                if (argumentResult.ExecuteExceptionInfo != null)
-                                {
-                                    throw new Exception(
-                                        GetInvalidCommandArgumentMessage(argument),
-                                        argumentResult.ExecuteExceptionInfo.SourceException);
-                                }
-
-                                if (!argumentResult.IsCompleteSubmission)
-                                {
-                                    throw new Exception(GetInvalidCommandArgumentMessage(argument));
-                                }
-
-                                argsToPass.Add(argumentResult.ReturnValue);
+                                argsToPass.Add(argument);
                             }
 
                             var commandResult = command.Value.Execute(this, argsToPass.ToArray());
                             return ProcessCommandResult(commandResult);
                         }
+                        // we have an invalid command - don't print the command colon again
+                        return ProcessCommandResult(string.Format("*** Invalid command: {0}", tokens[0].Substring(1)));
                     }
                 }
 

--- a/src/ScriptCs.Core/ReplCommands/AliasCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/AliasCommand.cs
@@ -33,7 +33,7 @@ namespace ScriptCs.ReplCommands
 
             if (args == null || args.Length != 2)
             {
-                _console.WriteLine("You must specifiy the command name and alias, e.g. :alias \"clear\" \"cls\"");
+                _console.WriteLine("You must specify the command name and alias, e.g. :alias \"clear\" \"cls\"");
                 return null;
             }
 

--- a/src/ScriptCs.Core/ReplCommands/HelpCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/HelpCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.Linq;
+using System.Text;
 using ScriptCs.Contracts;
 
 namespace ScriptCs.ReplCommands
@@ -31,10 +32,79 @@ namespace ScriptCs.ReplCommands
             _console.WriteLine("The following commands are available in the REPL:");
             foreach (var command in repl.Commands.OrderBy(x => x.Key))
             {
-                _console.WriteLine(string.Format(":{0,-15}{1,10}", command.Key, command.Value.Description));
+                string key = string.Format(" :{0,-15} - ", command.Key);
+                string desc = WrapTextToColumn(command.Value.Description, _console.Width - key.Length - 1, indentWidth: key.Length);
+
+                _console.WriteLine(string.Format("{0}{1,10}", key, desc));
             }
 
             return null;
+        }
+
+        /// <summary>
+        /// Word wrap text to specified column width.
+        /// </summary>
+        /// <param name="text">Unformatted text.</param>
+        /// <param name="columnWidth">Size of the column width.</param>
+        /// <param name="indentWidth">Indentation width when the text is wrap. The first line is not indented.</param>
+        /// <param name="initialWidth">First line indent width.</param>
+        /// <returns>Formatted text.</returns>
+        /// <remarks>In the future, I believe this method will be moved into some sort of formatting helper class.</remarks>
+        private string WrapTextToColumn(string text, int columnWidth, int indentWidth = 0, int initialWidth = 0)
+        {
+            // check the initial width
+            if ((initialWidth < 0) || (initialWidth > (indentWidth + columnWidth)))
+            {
+                throw new System.ArgumentOutOfRangeException("initialWidth");
+            }
+            
+            // TODO: Add additional parameter error checking
+                        
+            StringBuilder paragraph = new StringBuilder(text.Trim());
+
+            // add the initial space to text
+            paragraph.Insert(0, " ", initialWidth);
+
+            if (paragraph.Length > (columnWidth))
+            {
+                int pos = columnWidth;
+                int backSearchLimit = initialWidth;
+                do
+                {
+                    // find a whitespace we can wrap the description line
+                    int savedPos = pos;
+                    while (!char.IsWhiteSpace(paragraph[pos]))
+                    {
+                        pos--;
+
+                        // guard against not finding a natural whitespace
+                        // don't go below the spaces we create (indent)
+                        if (pos < backSearchLimit)
+                        {
+                            pos = savedPos;
+                            break;
+                        }
+                    }
+
+                    if (char.IsWhiteSpace(paragraph[pos]))
+                    {
+                        paragraph.Remove(pos, 1);    // remove the whitespace we found
+                    }
+                    // inject a newline   
+                    paragraph.Insert(pos, System.Environment.NewLine);
+                    pos += System.Environment.NewLine.Length;
+                    paragraph.Insert(pos, " ", indentWidth);
+                    pos += indentWidth;
+
+                    // prevent searching for whitespace to go below the spaces we put in
+                    backSearchLimit = pos; 
+
+                    pos += columnWidth;
+                } while (pos < paragraph.Length);
+
+            }
+
+            return paragraph.ToString();
         }
     }
 }

--- a/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
@@ -31,7 +31,7 @@ namespace ScriptCs.ReplCommands
 
         public string Description
         {
-            get { return "Installs a Nuget package. I.e. :install <package> <version>"; }
+            get { return "Installs a NuGet package. I.e. :install <package> <version>"; }
         }
 
         public string CommandName

--- a/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
+++ b/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
@@ -12,7 +12,7 @@ namespace ScriptCs.Engine.Mono.Segmenter.Lexer
 
         public ScriptLexer(string code)
         {
-            _position = -1; //inital pos
+            _position = -1; //initial pos
 
             _sr = new StringReader(code);
         }

--- a/src/ScriptCs.Engine.Mono/Segmenter/ScriptSegmenter.cs
+++ b/src/ScriptCs.Engine.Mono/Segmenter/ScriptSegmenter.cs
@@ -25,7 +25,7 @@ namespace ScriptCs.Engine.Mono.Segmenter
             {
                 foreach (var region in parser.Parse(code))
                 {
-                    // Calculate region linenumber
+                    // Calculate region line number
                     var lineNr = code.Substring(0, region.Offset).Count(x => x.Equals('\n'));
 
                     var segment = code.Substring(region.Offset, region.Length);

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
@@ -74,7 +74,7 @@ namespace ScriptCs.Engine.Roslyn
         {
             Logger.Debug("Retrieving compiled script class (reflection).");
 
-            // the following line can throw NullReferenceException, if that happens it's useful to notify that an error ocurred
+            // the following line can throw NullReferenceException, if that happens it's useful to notify that an error occurred
             var type = assembly.GetType(CompiledScriptClass);
             Logger.Debug("Retrieving compiled script method (reflection).");
             var method = type.GetMethod(CompiledScriptMethod, BindingFlags.Static | BindingFlags.Public);

--- a/src/ScriptCs.Hosting/FileConsole.cs
+++ b/src/ScriptCs.Hosting/FileConsole.cs
@@ -63,6 +63,11 @@ namespace ScriptCs.Hosting
             set { _innerConsole.ForegroundColor = value; }
         }
 
+        public int Width
+        {
+            get { return int.MaxValue; }
+        }
+
         private void Append(string text)
         {
             using (var writer = new StreamWriter(_path, true))

--- a/src/ScriptCs.Hosting/ScriptConsole.cs
+++ b/src/ScriptCs.Hosting/ScriptConsole.cs
@@ -57,5 +57,10 @@ namespace ScriptCs.Hosting
             get { return Console.ForegroundColor; }
             set { Console.ForegroundColor = value; }
         }
+
+        public int Width
+        {
+            get { return Console.BufferWidth; }
+        }
     }
 }

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -7,7 +7,6 @@ using LogLevel = ScriptCs.Contracts.LogLevel;
 
 namespace ScriptCs.Hosting
 {
-
     public class ScriptServicesBuilder : ServiceOverrides<IScriptServicesBuilder>, IScriptServicesBuilder
     {
         private readonly ITypeResolver _typeResolver;

--- a/test/ScriptCs.Core.Tests/ReplCommands/HelpCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/HelpCommandTests.cs
@@ -28,6 +28,8 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var console = new Mock<IConsole>();
+                console.Setup(c => c.Width).Returns(80);
+
                 var repl = new Mock<IRepl>();
                 var clearCommand = new ClearCommand(console.Object);
                 var exitCommand = new ExitCommand(console.Object);
@@ -47,8 +49,8 @@ namespace ScriptCs.Tests.ReplCommands
 
                 // assert
                 console.Verify(x => x.WriteLine(It.IsAny<string>()), Times.Exactly(3));
-                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(":" + clearCommand.CommandName) && f.Contains(clearCommand.Description))), Times.Once);
-                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(":" + exitCommand.CommandName) && f.Contains(exitCommand.Description))), Times.Once);
+                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(" :" + clearCommand.CommandName) && f.Contains(clearCommand.Description))), Times.Once);
+                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(" :" + exitCommand.CommandName) && f.Contains(exitCommand.Description))), Times.Once);
             }
 
             [Fact]
@@ -56,6 +58,8 @@ namespace ScriptCs.Tests.ReplCommands
             {
                 // arrange
                 var console = new Mock<IConsole>();
+                console.Setup(c => c.Width).Returns(80);
+
                 var repl = new Mock<IRepl>();
                 var clearCommand = new ClearCommand(console.Object);
                 var aliasCommand = new AliasCommand(console.Object);
@@ -75,9 +79,9 @@ namespace ScriptCs.Tests.ReplCommands
                 cmd.Execute(repl.Object, null);
 
                 // assert
-                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(":" + clearCommand.CommandName) && f.Contains(clearCommand.Description))), Times.Once);
-                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(":" + aliasCommand.CommandName) && f.Contains(aliasCommand.Description))), Times.Once);
-                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(":clr") && f.Contains(clearCommand.Description))), Times.Once);
+                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(" :" + clearCommand.CommandName) && f.Contains(clearCommand.Description))), Times.Once);
+                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(" :" + aliasCommand.CommandName) && f.Contains(aliasCommand.Description))), Times.Once);
+                console.Verify(x => x.WriteLine(It.Is<string>(f => f.StartsWith(" :clr") && f.Contains(clearCommand.Description))), Times.Once);
             }
         }
     }

--- a/test/ScriptCs.Core.Tests/ReplCommands/ScriptPacksCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/ScriptPacksCommandTests.cs
@@ -91,7 +91,7 @@ namespace ScriptCs.Tests.ReplCommands
         }
     }
 
-    class DummyScriptPack : IScriptPackContext
+    public class DummyScriptPack : IScriptPackContext
     {
         public string Foo(int bar)
         {
@@ -115,7 +115,6 @@ namespace ScriptCs.Tests.ReplCommands
     {
         public static void FooExtension(this DummyScriptPack dummyScriptPack)
         {
-
         }
     }
 }

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -235,7 +235,7 @@ namespace ScriptCs.Tests
                     It.IsAny<ScriptPackSession>()));
 
                 repl.Object.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
-                repl.Object.Execute("", new string[]{});
+                repl.Object.Execute("", new string[] {});
 
                 scriptEngine.Verify(
                     e => e.Execute(

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -154,7 +154,7 @@ namespace ScriptCs.Tests
                 scriptExecutor.Initialize(destPaths, Enumerable.Empty<IScriptPack>());
 
                 // act
-                scriptExecutor.EngineExecute("", new string[]{}, new FilePreProcessorResult());
+                scriptExecutor.EngineExecute("", new string[] {}, new FilePreProcessorResult());
 
                 // assert
                 scriptEngine.Verify(
@@ -185,7 +185,7 @@ namespace ScriptCs.Tests
                 scriptExecutor.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
 
                 // act
-                scriptExecutor.EngineExecute("", new string[]{}, new FilePreProcessorResult() {Code = code});
+                scriptExecutor.EngineExecute("", new string[] {}, new FilePreProcessorResult() {Code = code});
 
                 // assert
 
@@ -222,7 +222,7 @@ namespace ScriptCs.Tests
 
 
                 scriptExecutor.Object.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
-                scriptExecutor.Object.EngineExecute("", new string[]{}, result);
+                scriptExecutor.Object.EngineExecute("", new string[] {}, result);
 
                 scriptEngine.Verify(
                     e => e.Execute(
@@ -257,7 +257,7 @@ namespace ScriptCs.Tests
 
 
                 scriptExecutor.Object.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
-                scriptExecutor.Object.EngineExecute("", new string[]{}, result);
+                scriptExecutor.Object.EngineExecute("", new string[] {}, result);
 
                 scriptEngine.Verify(
                     e => e.Execute(
@@ -345,7 +345,7 @@ namespace ScriptCs.Tests
                 executor.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
 
                 // act
-                executor.EngineExecute("", new string[]{}, new FilePreProcessorResult());
+                executor.EngineExecute("", new string[] {}, new FilePreProcessorResult());
 
                 // assert
                 engine.Verify(
@@ -369,7 +369,7 @@ namespace ScriptCs.Tests
                 
                 var result = new FilePreProcessorResult();
 
-                executor.Object.EngineExecute("", new string[]{ }, result);
+                executor.Object.EngineExecute("", new string[] { }, result);
                
                 executor.Verify(e => e.InjectScriptLibraries(
                     It.IsAny<string>(), result, It.IsAny<IDictionary<string, object>>()));


### PR DESCRIPTION
By removing the evaluation of arguments, it allows a cleaner command-line arguments.

![cleaner command arguments](https://cloud.githubusercontent.com/assets/550820/7577448/49a6e0ee-f816-11e4-874e-2ee6a746dfea.png)

