### PR TITLE
Keep quoted strings together when splitting REPL Command line arguments

### DIFF
--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -55,7 +55,7 @@ namespace ScriptCs
             {
                 if (script.StartsWith(":"))
                 {
-                    var tokens = script.Split(' ');
+                    var tokens = script.SplitQuoted();
                     if (tokens[0].Length > 1)
                     {
                         var command = Commands.FirstOrDefault(x => x.Key == tokens[0].Substring(1));
@@ -93,6 +93,8 @@ namespace ScriptCs
                             var commandResult = command.Value.Execute(this, argsToPass.ToArray());
                             return ProcessCommandResult(commandResult);
                         }
+                        // since the command that was type is not found - say so
+                        return ProcessCommandResult(string.Format("*** Invalid command: {0}", tokens[0].Substring(1)));
                     }
                 }
 

--- a/src/ScriptCs.Core/StringExtensions.cs
+++ b/src/ScriptCs.Core/StringExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace ScriptCs
 {
@@ -7,6 +8,104 @@ namespace ScriptCs
         public static string DefineTrace(this string code)
         {
             return string.Format("#define TRACE{0}{1}", Environment.NewLine, code);
+        }
+
+        /// <summary>
+        /// Split string on whitespace, but keeps string with quotes together
+        /// For example: :cd "\\Foo Bar"
+        ///             :cd
+        ///             "\\Foo Bar".
+        /// </summary>
+        /// <param name="argument">String with or without quotes.</param>
+        /// <returns>Array of strings.</returns>
+        public static string[] SplitQuoted(this string argument)
+        {
+            if (string.IsNullOrWhiteSpace(argument))
+            {
+                return argument.Split(' ');
+            }
+
+            // count the number of quotes and throw something is not even
+            // the fastest way is to just loop thru the string
+            // http://cc.davelozinski.com/c-sharp/fastest-way-to-check-if-a-string-occurs-within-a-string
+            Func<string, int> quoteCounterFunc = delegate (string line)
+            {
+                int count = 0;
+                for (int x = 0; x < line.Length; x++)
+                {
+                    if (line[x] == '"')
+                    {
+                        count++;
+                    }
+                }
+                return count;
+            };
+            int quotes = quoteCounterFunc(argument);
+            if ((quotes % 2) != 0)
+            {
+                throw new ArgumentException("String is missing a closing quote");
+            }
+
+            List<string> list = new List<string>(argument.Split(' '));
+
+            // quoted string needs to be combine back together
+            if (quotes > 0 && list.Count > 0)
+            {
+                Predicate<string> findQuoteFunc = delegate (string s) { return s.Contains("\""); };
+                // create function to find string item with odd number of quotes
+                Func<int, int> findOddQuotedItemFunc = delegate (int startingIndex) {
+                    if (startingIndex < list.Count)
+                    {
+                        do
+                        {
+                            int quickFind = list.FindIndex(startingIndex, findQuoteFunc);
+                            int quickCount = quoteCounterFunc(list[quickFind]);
+                            if ((quickCount % 2) != 0)
+                            {
+                                return quickFind;
+                            }
+                            // we didn't find the quoted line we are looking for
+                            startingIndex = quickFind + 1;
+                        } while (startingIndex < list.Count);
+                    }
+                    return -1;
+                };
+
+                int index = 0;
+                do
+                {
+                    int start = findOddQuotedItemFunc(index);
+                    if (start > 0)
+                    {
+                        // we have to locate the next string with odd number of quotes
+                        int end = findOddQuotedItemFunc(start + 1);
+
+                        string combined = string.Empty;
+                        for (int x = start; x <= end; x++)
+                        {
+                            // because we split on whitespace, we have to put it back when combining
+                            combined += list[x] + ' ';
+                        }
+                        list[start] = combined.TrimEnd(); // remove the extra whitespace that was added
+
+                        // removed the other parts of the combined string from the list
+                        do
+                        {
+                            list.RemoveAt(end--); // from the bottom up
+                        } while (start < end);
+
+                        // advance to next item in the adjusted list
+                        index = start + 1;
+                    }
+                    else
+                    {
+                        break;
+                    }
+
+                } while (index < list.Count);
+            }
+
+            return list.ToArray();
         }
 
         public static string UndefineTrace(this string code)

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="ScriptPackResolverTests.cs" />
     <Compile Include="ScriptPackSessionTests.cs" />
     <Compile Include="ShebangLineProcessorTests.cs" />
+    <Compile Include="StringExtensionTests.cs" />
     <Compile Include="UsingLineProcessorTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Core.Tests/StringExtensionTests.cs
+++ b/test/ScriptCs.Core.Tests/StringExtensionTests.cs
@@ -1,0 +1,31 @@
+﻿using Should;
+using Xunit;
+using System;
+
+namespace ScriptCs.Tests
+{
+    public class StringExtensionTests
+    {
+        public class TheSplitQuotedMethod
+        {
+            [Fact]
+            public void ShouldKeepQuotedStringTogether()
+            {
+                string line = ":cd \"\\\\Foo Bar\"";
+                var result = line.SplitQuoted();
+
+                result.Length.ShouldEqual(2);
+                result[0].ShouldEqual(":cd");
+                result[1].ShouldEqual("\"\\\\Foo Bar\"");
+            }
+
+            [Fact]
+            public void MissingQuoteThrowException()
+            {
+                string line = ":alias \"clear\" \"wipe";
+
+                Assert.Throws(typeof(ArgumentException), () => line.SplitQuoted());
+            }
+        }
+    }
+}


### PR DESCRIPTION
Because the Repl Command line was getting split with white space, it wouldn't handle quoted text with white space.  Now you can use the "Change Directory" command with long path name.  In the screen shot below, I demonstrate missing quotes and long path names with white space.

![foo 01](https://cloud.githubusercontent.com/assets/550820/7624048/ba7c880a-f9b0-11e4-8bc4-e92afe87f58c.png)
