### PR TITLE
restore deprecated Common.Logging overloads #847

### DIFF
--- a/src/ScriptCs.Core/AppDomainAssemblyResolver.cs
+++ b/src/ScriptCs.Core/AppDomainAssemblyResolver.cs
@@ -14,6 +14,18 @@ namespace ScriptCs
         private readonly IAssemblyUtility _assemblyUtility;
         private readonly IDictionary<string, AssemblyInfo> _assemblyInfoMap;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public AppDomainAssemblyResolver(
+            Common.Logging.ILog logger,
+            IFileSystem fileSystem,
+            IAssemblyResolver resolver,
+            IAssemblyUtility assemblyUtility,
+            IDictionary<string, AssemblyInfo> assemblyInfoMap = null,
+            Func<object, ResolveEventArgs, Assembly> resolveHandler = null)
+            : this(new CommonLoggingLogProvider(logger), fileSystem, resolver, assemblyUtility, assemblyInfoMap, resolveHandler)
+        {
+        }
+
         public AppDomainAssemblyResolver(
             ILogProvider logProvider,
             IFileSystem fileSystem,

--- a/src/ScriptCs.Core/AssemblyResolver.cs
+++ b/src/ScriptCs.Core/AssemblyResolver.cs
@@ -14,6 +14,16 @@ namespace ScriptCs
         private readonly IAssemblyUtility _assemblyUtility;
         private readonly ILog _logger;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public AssemblyResolver(
+            IFileSystem fileSystem,
+            IPackageAssemblyResolver packageAssemblyResolver,
+            IAssemblyUtility assemblyUtility,
+            Common.Logging.ILog logger)
+            :this(fileSystem,packageAssemblyResolver,assemblyUtility,new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public AssemblyResolver(
             IFileSystem fileSystem,
             IPackageAssemblyResolver packageAssemblyResolver,

--- a/src/ScriptCs.Core/CommonLoggingLogProvider.cs
+++ b/src/ScriptCs.Core/CommonLoggingLogProvider.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Globalization;
+using ScriptCs.Contracts;
+
+namespace ScriptCs
+{
+    [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+    public class CommonLoggingLogProvider : ILogProvider
+    {
+        private readonly Common.Logging.ILog _logger;
+
+        public CommonLoggingLogProvider(Common.Logging.ILog logger)
+        {
+            Guard.AgainstNullArgument("logger", logger);
+
+            _logger = logger;
+        }
+
+        public Logger GetLogger(string name)
+        {
+            return Log;
+        }
+
+        public IDisposable OpenNestedContext(string message)
+        {
+            throw new NotImplementedException();
+        }
+
+        public IDisposable OpenMappedContext(string key, string value)
+        {
+            throw new NotImplementedException();
+        }
+
+        private bool Log(LogLevel logLevel, Func<string> messageFunc, Exception exception, params object[] formatParameters)
+        {
+            if (messageFunc == null)
+            {
+                return IsEnabled(logLevel);
+            }
+
+            messageFunc = Format(messageFunc, formatParameters);
+
+            if (exception != null)
+            {
+                return LogException(logLevel, messageFunc, exception);
+            }
+
+            switch (logLevel)
+            {
+                case LogLevel.Debug:
+                    if (_logger.IsDebugEnabled)
+                    {
+                        _logger.Debug(messageFunc());
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Info:
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info(messageFunc());
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Warn:
+                    if (_logger.IsWarnEnabled)
+                    {
+                        _logger.Warn(messageFunc());
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Error:
+                    if (_logger.IsErrorEnabled)
+                    {
+                        _logger.Error(messageFunc());
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Fatal:
+                    if (_logger.IsFatalEnabled)
+                    {
+                        _logger.Fatal(messageFunc());
+                        return true;
+                    }
+                    break;
+
+                default:
+                    if (_logger.IsTraceEnabled)
+                    {
+                        _logger.Trace(messageFunc());
+                        return true;
+                    }
+
+                    break;
+            }
+
+            return false;
+        }
+
+        private bool LogException(LogLevel logLevel, Func<string> messageFunc, Exception exception)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Debug:
+                    if (_logger.IsDebugEnabled)
+                    {
+                        _logger.Debug(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Info:
+                    if (_logger.IsInfoEnabled)
+                    {
+                        _logger.Info(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Warn:
+                    if (_logger.IsWarnEnabled)
+                    {
+                        _logger.Warn(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Error:
+                    if (_logger.IsErrorEnabled)
+                    {
+                        _logger.Error(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+                case LogLevel.Fatal:
+                    if (_logger.IsFatalEnabled)
+                    {
+                        _logger.Fatal(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+                default:
+                    if (_logger.IsTraceEnabled)
+                    {
+                        _logger.Trace(messageFunc(), exception);
+                        return true;
+                    }
+
+                    break;
+            }
+
+            return false;
+        }
+
+        private bool IsEnabled(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Debug:
+                    return _logger.IsDebugEnabled;
+                case LogLevel.Info:
+                    return _logger.IsInfoEnabled;
+                case LogLevel.Warn:
+                    return _logger.IsWarnEnabled;
+                case LogLevel.Error:
+                    return _logger.IsErrorEnabled;
+                case LogLevel.Fatal:
+                    return _logger.IsFatalEnabled;
+                default:
+                    return _logger.IsTraceEnabled;
+            }
+        }
+
+        private static Func<string> Format(Func<string> messageFunc, object[] formatParameters)
+        {
+            if (formatParameters == null || formatParameters.Length == 0)
+            {
+                return messageFunc;
+            }
+
+            return () =>
+            {
+                var format = messageFunc();
+                try
+                {
+                    return string.Format(CultureInfo.InvariantCulture, format, formatParameters);
+                }
+                catch (FormatException ex)
+                {
+                    throw new FormatException("The input string '" + format + "' could not be formatted using string.Format", ex);
+                }
+            };
+        }
+    }
+}

--- a/src/ScriptCs.Core/DebugScriptExecutor.cs
+++ b/src/ScriptCs.Core/DebugScriptExecutor.cs
@@ -1,9 +1,16 @@
-﻿using ScriptCs.Contracts;
+﻿using System;
+using ScriptCs.Contracts;
 
 namespace ScriptCs
 {
     public class DebugScriptExecutor : ScriptExecutor
     {
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public DebugScriptExecutor(IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, Common.Logging.ILog logger, IScriptLibraryComposer composer)
+            : this(fileSystem, filePreProcessor, scriptEngine, new CommonLoggingLogProvider(logger), composer)
+        {
+        }
+
         public DebugScriptExecutor(IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider, IScriptLibraryComposer composer)
             : base(fileSystem, filePreProcessor, scriptEngine, logProvider, composer)
         {

--- a/src/ScriptCs.Core/FilePreProcessor.cs
+++ b/src/ScriptCs.Core/FilePreProcessor.cs
@@ -14,6 +14,12 @@ namespace ScriptCs
 
         private readonly IFileSystem _fileSystem;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public FilePreProcessor(IFileSystem fileSystem, Common.Logging.ILog logger, IEnumerable<ILineProcessor> lineProcessors)
+            : this(fileSystem, new CommonLoggingLogProvider(logger), lineProcessors)
+        {
+        }
+
         public FilePreProcessor(IFileSystem fileSystem, ILogProvider logProvider, IEnumerable<ILineProcessor> lineProcessors)
         {
             Guard.AgainstNullArgument("fileSystem", fileSystem);

--- a/src/ScriptCs.Core/FileSystemMigrator.cs
+++ b/src/ScriptCs.Core/FileSystemMigrator.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using ScriptCs.Contracts;
 
@@ -11,6 +12,12 @@ namespace ScriptCs
         private readonly Dictionary<string, string> _fileCopies;
         private readonly Dictionary<string, string> _directoryMoves;
         private readonly Dictionary<string, string> _directoryCopies;
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public FileSystemMigrator(IFileSystem fileSystem, Common.Logging.ILog logger)
+            : this(fileSystem, new CommonLoggingLogProvider(logger))
+        {
+        }
 
         public FileSystemMigrator(IFileSystem fileSystem, ILogProvider logProvider)
         {

--- a/src/ScriptCs.Core/ILoggerConfigurator.cs
+++ b/src/ScriptCs.Core/ILoggerConfigurator.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using ScriptCs.Contracts;
+
+namespace ScriptCs
+{
+    [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+    public interface ILoggerConfigurator
+    {
+        void Configure(IConsole console);
+        
+        Common.Logging.ILog GetLogger();
+    }
+}

--- a/src/ScriptCs.Core/PackageAssemblyResolver.cs
+++ b/src/ScriptCs.Core/PackageAssemblyResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using ScriptCs.Contracts;
@@ -13,6 +14,13 @@ namespace ScriptCs
         private readonly IAssemblyUtility _assemblyUtility;
 
         private List<IPackageReference> _topLevelPackages;
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public PackageAssemblyResolver(
+            IFileSystem fileSystem, IPackageContainer packageContainer, Common.Logging.ILog logger, IAssemblyUtility assemblyUtility)
+            : this(fileSystem, packageContainer, new CommonLoggingLogProvider(logger), assemblyUtility)
+        {
+        }
 
         public PackageAssemblyResolver(
             IFileSystem fileSystem, IPackageContainer packageContainer, ILogProvider logProvider, IAssemblyUtility assemblyUtility)

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -14,6 +14,30 @@ namespace ScriptCs
         private readonly IObjectSerializer _serializer;
         private readonly ILog _log;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public Repl(
+            string[] scriptArgs,
+            IFileSystem fileSystem,
+            IScriptEngine scriptEngine,
+            IObjectSerializer serializer,
+            Common.Logging.ILog logger,
+            IScriptLibraryComposer composer,
+            IConsole console,
+            IFilePreProcessor filePreProcessor,
+            IEnumerable<IReplCommand> replCommands)
+            : this(
+                scriptArgs,
+                fileSystem,
+                scriptEngine,
+                serializer,
+                new CommonLoggingLogProvider(logger),
+                composer,
+                console,
+                filePreProcessor,
+                replCommands)
+        {
+        }
+
         public Repl(
             string[] scriptArgs,
             IFileSystem fileSystem,

--- a/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
+++ b/src/ScriptCs.Core/ReplCommands/InstallCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using System.Runtime.Versioning;
 using ScriptCs.Contracts;
 
@@ -10,6 +11,16 @@ namespace ScriptCs.ReplCommands
         private readonly IPackageAssemblyResolver _packageAssemblyResolver;
         private readonly ILog _logger;
         private readonly IInstallationProvider _installationProvider;
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public InstallCommand(
+            IPackageInstaller packageInstaller,
+            IPackageAssemblyResolver packageAssemblyResolver,
+            Common.Logging.ILog logger,
+            IInstallationProvider installationProvider)
+            :this(packageInstaller, packageAssemblyResolver,new CommonLoggingLogProvider(logger), installationProvider)
+        {
+        }
 
         public InstallCommand(
             IPackageInstaller packageInstaller,

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -34,6 +34,10 @@
     <CodeAnalysisRuleSet>..\..\ScriptCs.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Core" />
@@ -48,12 +52,15 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="AssemblyUtility.cs" />
+    <Compile Include="CommonLoggingLogProvider.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="FileSystemMigrator.cs" />
+    <Compile Include="ILoggerConfigurator.cs" />
     <Compile Include="NullScriptLibraryComposer.cs" />
     <Compile Include="ReplCommands\ScriptPacksCommand.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
+    <Compile Include="ScriptCsLogger.cs" />
     <Compile Include="ScriptLibraryComposer.cs" />
     <Compile Include="ScriptLibraryWrapper.cs" />
     <Compile Include="ReplCommands\AliasCommand.cs" />

--- a/src/ScriptCs.Core/ScriptCsLogger.cs
+++ b/src/ScriptCs.Core/ScriptCsLogger.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using ScriptCs.Contracts;
+
+namespace ScriptCs
+{
+    [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+    public class ScriptCsLogger : Common.Logging.Factory.AbstractLogger
+    {
+        private readonly ILog _log;
+
+        public ScriptCsLogger(ILog log)
+        {
+            Guard.AgainstNullArgument("log", log);
+
+            _log = log;
+        }
+
+        protected override void WriteInternal(Common.Logging.LogLevel level, object message, Exception exception)
+        {
+            if (level == Common.Logging.LogLevel.Off)
+            {
+                return;
+            }
+
+            _log.Log(Map(level), () => message == null ? null : message.ToString(), exception);
+        }
+
+        public override bool IsTraceEnabled
+        {
+            get { return _log.IsTraceEnabled(); }
+        }
+
+        public override bool IsDebugEnabled
+        {
+            get { return _log.IsDebugEnabled(); }
+        }
+
+        public override bool IsErrorEnabled
+        {
+            get { return _log.IsErrorEnabled(); }
+        }
+
+        public override bool IsFatalEnabled
+        {
+            get { return _log.IsFatalEnabled(); }
+        }
+
+        public override bool IsInfoEnabled
+        {
+            get { return _log.IsInfoEnabled(); }
+        }
+
+        public override bool IsWarnEnabled
+        {
+            get { return _log.IsWarnEnabled(); }
+        }
+
+        private static LogLevel Map(Common.Logging.LogLevel level)
+        {
+            switch (level)
+            {
+                case Common.Logging.LogLevel.All:
+                    return LogLevel.Trace;
+                case Common.Logging.LogLevel.Debug:
+                    return LogLevel.Debug;
+                case Common.Logging.LogLevel.Error:
+                    return LogLevel.Error;
+                case Common.Logging.LogLevel.Fatal:
+                    return LogLevel.Fatal;
+                case Common.Logging.LogLevel.Info:
+                    return LogLevel.Info;
+                case Common.Logging.LogLevel.Trace:
+                    return LogLevel.Trace;
+                case Common.Logging.LogLevel.Warn:
+                    return LogLevel.Warn;
+            }
+
+            throw new NotSupportedException("Unknown log level.");
+        }
+    }
+}

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -44,6 +44,9 @@ namespace ScriptCs
 
         public IScriptEngine ScriptEngine { get; private set; }
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public Common.Logging.ILog Logger { get; private set; }
+
         public AssemblyReferences References { get; private set; }
 
         public ICollection<string> Namespaces { get; private set; }
@@ -52,9 +55,27 @@ namespace ScriptCs
 
         public IScriptLibraryComposer ScriptLibraryComposer { get; protected set; }
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ScriptExecutor(
+            IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, Common.Logging.ILog logger)
+            : this(fileSystem, filePreProcessor, scriptEngine, new CommonLoggingLogProvider(logger), new NullScriptLibraryComposer())
+        {
+        }
+
         public ScriptExecutor(
             IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider)
             : this(fileSystem, filePreProcessor, scriptEngine, logProvider, new NullScriptLibraryComposer())
+        {
+        }
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ScriptExecutor(
+            IFileSystem fileSystem,
+            IFilePreProcessor filePreProcessor,
+            IScriptEngine scriptEngine,
+            Common.Logging.ILog logger,
+            IScriptLibraryComposer composer)
+            : this(fileSystem, filePreProcessor, scriptEngine, new CommonLoggingLogProvider(logger), composer)
         {
         }
 
@@ -80,6 +101,9 @@ namespace ScriptCs
             FilePreProcessor = filePreProcessor;
             ScriptEngine = scriptEngine;
             _log = logProvider.ForCurrentType();
+#pragma warning disable 618
+            Logger = new ScriptCsLogger(_log);
+#pragma warning restore 618
             ScriptLibraryComposer = composer;
         }
 

--- a/src/ScriptCs.Core/ScriptLibraryComposer.cs
+++ b/src/ScriptCs.Core/ScriptLibraryComposer.cs
@@ -15,6 +15,12 @@ namespace ScriptCs
         private readonly IPackageAssemblyResolver _packageAssemblyResolver;
         private readonly ILog _logger;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ScriptLibraryComposer(IFileSystem fileSystem, IFilePreProcessor preProcessor, IPackageContainer packageContainer, IPackageAssemblyResolver packageAssemblyResolver, Common.Logging.ILog logger)
+            : this(fileSystem, preProcessor, packageContainer, packageAssemblyResolver, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public ScriptLibraryComposer(IFileSystem fileSystem, IFilePreProcessor preProcessor, IPackageContainer packageContainer, IPackageAssemblyResolver packageAssemblyResolver, ILogProvider logProvider)
         {
             Guard.AgainstNullArgument("fileSystem", fileSystem);

--- a/src/ScriptCs.Core/ScriptServices.cs
+++ b/src/ScriptCs.Core/ScriptServices.cs
@@ -1,10 +1,51 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using ScriptCs.Contracts;
 
 namespace ScriptCs
 {
     public class ScriptServices
     {
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ScriptServices(
+            IFileSystem fileSystem,
+            IPackageAssemblyResolver packageAssemblyResolver,
+            IScriptExecutor executor,
+            IRepl repl,
+            IScriptEngine engine,
+            IFilePreProcessor filePreProcessor,
+            IScriptPackResolver scriptPackResolver,
+            IPackageInstaller packageInstaller,
+            IObjectSerializer objectSerializer,
+            Common.Logging.ILog logger,
+            IAssemblyResolver assemblyResolver,
+            IEnumerable<IReplCommand> replCommands,
+            IFileSystemMigrator fileSystemMigrator,
+            IConsole console = null,
+            IInstallationProvider installationProvider = null,
+            IScriptLibraryComposer scriptLibraryComposer = null
+            )
+            : this(
+                fileSystem,
+                packageAssemblyResolver,
+                executor,
+                repl,
+                engine,
+                filePreProcessor,
+                scriptPackResolver,
+                packageInstaller,
+                objectSerializer,
+                new CommonLoggingLogProvider(logger),
+                assemblyResolver,
+                replCommands,
+                fileSystemMigrator,
+                console,
+                installationProvider,
+                scriptLibraryComposer
+            )
+        {
+        }
+
         public ScriptServices(
             IFileSystem fileSystem,
             IPackageAssemblyResolver packageAssemblyResolver,
@@ -34,6 +75,9 @@ namespace ScriptCs
             PackageInstaller = packageInstaller;
             ObjectSerializer = objectSerializer;
             LogProvider = logProvider;
+#pragma warning disable 618
+            Logger = new ScriptCsLogger(logProvider.ForCurrentType());
+#pragma warning restore 618
             Console = console;
             AssemblyResolver = assemblyResolver;
             InstallationProvider = installationProvider;
@@ -50,6 +94,10 @@ namespace ScriptCs
         public IPackageInstaller PackageInstaller { get; private set; }
         public IObjectSerializer ObjectSerializer { get; private set; }
         public ILogProvider LogProvider { get; private set; }
+        
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public Common.Logging.ILog Logger { get; private set; }
+        
         public IScriptEngine Engine { get; private set; }
         public IFilePreProcessor FilePreProcessor { get; private set; }
         public IConsole Console { get; private set; }

--- a/src/ScriptCs.Core/packages.config
+++ b/src/ScriptCs.Core/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="LiteGuard.Source" version="0.8.0" targetFramework="net45" developmentDependency="true" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/ScriptCs.Engine.Mono/MonoScriptEngine.cs
+++ b/src/ScriptCs.Engine.Mono/MonoScriptEngine.cs
@@ -22,6 +22,12 @@ namespace ScriptCs.Engine.Mono
         public string CacheDirectory { get; set; }
         public string FileName { get; set; }
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public MonoScriptEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public MonoScriptEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider)
         {
             Guard.AgainstNullArgument("logProvider", logProvider);

--- a/src/ScriptCs.Engine.Mono/ScriptCs.Engine.Mono.csproj
+++ b/src/ScriptCs.Engine.Mono/ScriptCs.Engine.Mono.csproj
@@ -34,6 +34,10 @@
     <CodeAnalysisRuleSet>..\..\ScriptCs.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="ICSharpCode.NRefactory, Version=5.0.0.0, Culture=neutral, PublicKeyToken=d4bfe873e7598c49, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\ICSharpCode.NRefactory.5.5.1\lib\Net40\ICSharpCode.NRefactory.dll</HintPath>

--- a/src/ScriptCs.Engine.Mono/packages.config
+++ b/src/ScriptCs.Engine.Mono/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="ICSharpCode.NRefactory" version="5.5.1" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.5.4" targetFramework="net45" />
   <package id="Mono.CSharp" version="4.0.0.143" targetFramework="net45" />

--- a/src/ScriptCs.Engine.Roslyn/RoslynReplEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynReplEngine.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Reflection;
@@ -11,6 +12,12 @@ namespace ScriptCs.Engine.Roslyn
 
     public class RoslynReplEngine : RoslynScriptEngine, IReplEngine
     {
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public RoslynReplEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public RoslynReplEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider)
             : base(scriptHostFactory, logProvider)
         {

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptCompilerEngine.cs
@@ -16,6 +16,12 @@ namespace ScriptCs.Engine.Roslyn
 
         private readonly ILog _log;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        protected RoslynScriptCompilerEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         protected RoslynScriptCompilerEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider)
             : base(scriptHostFactory, logProvider)
         {

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptEngine.cs
@@ -19,6 +19,12 @@ namespace ScriptCs.Engine.Roslyn
         public const string SessionKey = "Session";
         private const string InvalidNamespaceError = "error CS0246";
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public RoslynScriptEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public RoslynScriptEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider)
         {
             Guard.AgainstNullArgument("logProvider", logProvider);
@@ -26,7 +32,13 @@ namespace ScriptCs.Engine.Roslyn
             ScriptEngine = new ScriptEngine();
             _scriptHostFactory = scriptHostFactory;
             _log = logProvider.ForCurrentType();
+#pragma warning disable 618
+            Logger = new ScriptCsLogger(_log);
+#pragma warning restore 618
         }
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        protected Common.Logging.ILog Logger { get; private set; }
 
         public string BaseDirectory
         {

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptInMemoryEngine.cs
@@ -8,6 +8,12 @@ namespace ScriptCs.Engine.Roslyn
     {
         private readonly ILog _log;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public RoslynScriptInMemoryEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public RoslynScriptInMemoryEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider)
             : base(scriptHostFactory, logProvider)
         {

--- a/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
+++ b/src/ScriptCs.Engine.Roslyn/RoslynScriptPersistentEngine.cs
@@ -12,6 +12,12 @@ namespace ScriptCs.Engine.Roslyn
         private readonly IFileSystem _fileSystem;
         private const string RoslynAssemblyNameCharacter = "ℛ";
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public RoslynScriptPersistentEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger, IFileSystem fileSystem)
+            : this(scriptHostFactory, new CommonLoggingLogProvider(logger), fileSystem)
+        {
+        }
+
         public RoslynScriptPersistentEngine(IScriptHostFactory scriptHostFactory, ILogProvider logProvider, IFileSystem fileSystem)
             : base(scriptHostFactory, logProvider)
         {

--- a/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
+++ b/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
@@ -34,6 +34,10 @@
     <CodeAnalysisRuleSet>..\..\ScriptCs.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Roslyn.Compilers">
       <HintPath>..\..\packages\Roslyn.Compilers.Common.1.2.20906.2\lib\net45\Roslyn.Compilers.dll</HintPath>
     </Reference>

--- a/src/ScriptCs.Engine.Roslyn/packages.config
+++ b/src/ScriptCs.Engine.Roslyn/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Roslyn.Compilers.Common" version="1.2.20906.2" targetFramework="net45" />
   <package id="Roslyn.Compilers.CSharp" version="1.2.20906.2" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />

--- a/src/ScriptCs.Hosting/IInitializationServices.cs
+++ b/src/ScriptCs.Hosting/IInitializationServices.cs
@@ -1,4 +1,5 @@
-﻿using ScriptCs.Contracts;
+﻿using System;
+using ScriptCs.Contracts;
 
 namespace ScriptCs.Hosting
 {
@@ -15,6 +16,9 @@ namespace ScriptCs.Hosting
         IPackageAssemblyResolver GetPackageAssemblyResolver();
 
         IPackageInstaller GetPackageInstaller();
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        Common.Logging.ILog Logger { get; }
 
         ILogProvider LogProvider { get; }
 

--- a/src/ScriptCs.Hosting/InitializationServices.cs
+++ b/src/ScriptCs.Hosting/InitializationServices.cs
@@ -10,6 +10,12 @@ namespace ScriptCs.Hosting
     {
         private readonly ILog _log;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public InitializationServices(Common.Logging.ILog logger, IDictionary<Type, object> overrides = null)
+            : this(new CommonLoggingLogProvider(logger), overrides)
+        {
+        }
+
         public InitializationServices(ILogProvider logProvider, IDictionary<Type, object> overrides = null)
             : base(logProvider, overrides)
         {

--- a/src/ScriptCs.Hosting/LoggerConfigurator.cs
+++ b/src/ScriptCs.Hosting/LoggerConfigurator.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using ScriptCs.Contracts;
+using LogLevel = ScriptCs.Contracts.LogLevel;
+
+namespace ScriptCs.Hosting
+{
+    [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+    public class LoggerConfigurator : ILoggerConfigurator
+    {
+        private const string LoggerName = "scriptcs";
+
+        private readonly LogLevel _logLevel;
+
+        private Common.Logging.ILog _logger;
+
+        public LoggerConfigurator(LogLevel logLevel)
+        {
+            _logLevel = logLevel;
+        }
+
+        public void Configure(IConsole console)
+        {
+            _logger = new ScriptConsoleLogger(_logLevel, console, Common.Logging.LogManager.GetLogger(LoggerName));
+        }
+
+        public Common.Logging.ILog GetLogger()
+        {
+            return _logger;
+        }
+    }
+}

--- a/src/ScriptCs.Hosting/ModuleLoader.cs
+++ b/src/ScriptCs.Hosting/ModuleLoader.cs
@@ -26,6 +26,19 @@ namespace ScriptCs.Hosting
         private readonly IFileSystem _fileSystem;
         private readonly IAssemblyUtility _assemblyUtility;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        [ImportingConstructor]
+        public ModuleLoader(IAssemblyResolver resolver, Common.Logging.ILog logger, IFileSystem fileSystem, IAssemblyUtility assemblyUtility)
+            : this(resolver, new CommonLoggingLogProvider(logger), fileSystem, assemblyUtility)
+        {
+        }
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ModuleLoader(IAssemblyResolver resolver, Common.Logging.ILog logger, Action<Assembly, AggregateCatalog> addToCatalog, Func<CompositionContainer, IEnumerable<Lazy<IModule, IModuleMetadata>>> getLazyModules, IFileSystem fileSystem, IAssemblyUtility assemblyUtility)
+            : this(resolver, new CommonLoggingLogProvider(logger), addToCatalog, getLazyModules, fileSystem, assemblyUtility)
+        {
+        }
+
         [ImportingConstructor]
         public ModuleLoader(IAssemblyResolver resolver, ILogProvider logProvider, IFileSystem fileSystem, IAssemblyUtility assemblyUtility) :
             this(resolver, logProvider, null, null, fileSystem, assemblyUtility)

--- a/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
+++ b/src/ScriptCs.Hosting/Package/NugetInstallationProvider.cs
@@ -17,6 +17,12 @@ namespace ScriptCs.Hosting.Package
 
         private static readonly Version EmptyVersion = new Version();
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public NugetInstallationProvider(IFileSystem fileSystem, Common.Logging.ILog logger)
+            : this(fileSystem, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public NugetInstallationProvider(IFileSystem fileSystem, ILogProvider logProvider)
         {
             Guard.AgainstNullArgument("fileSystem", fileSystem);

--- a/src/ScriptCs.Hosting/Package/PackageContainer.cs
+++ b/src/ScriptCs.Hosting/Package/PackageContainer.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -17,6 +18,12 @@ namespace ScriptCs.Hosting.Package
         private readonly IFileSystem _fileSystem;
 
         private readonly ILog _logger;
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public PackageContainer(IFileSystem fileSystem, Common.Logging.ILog logger)
+            : this(fileSystem, new CommonLoggingLogProvider(logger))
+        {
+        }
 
         public PackageContainer(IFileSystem fileSystem, ILogProvider logProvider)
         {

--- a/src/ScriptCs.Hosting/Package/PackageInstaller.cs
+++ b/src/ScriptCs.Hosting/Package/PackageInstaller.cs
@@ -10,6 +10,12 @@ namespace ScriptCs.Hosting.Package
         private readonly IInstallationProvider _installer;
         private readonly ILog _logger;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public PackageInstaller(IInstallationProvider installer, Common.Logging.ILog logger)
+            : this(installer, new CommonLoggingLogProvider(logger))
+        {
+        }
+
         public PackageInstaller(IInstallationProvider installer, ILogProvider logProvider)
         {
             Guard.AgainstNullArgument("installer", installer);

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -21,6 +21,30 @@ namespace ScriptCs.Hosting
         private readonly IInitializationServices _initializationServices;
         private readonly string _scriptName;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public RuntimeServices(
+            Common.Logging.ILog logger,
+            IDictionary<Type, object> overrides,
+            IConsole console,
+            Type scriptEngineType,
+            Type scriptExecutorType,
+            Type replType,
+            bool initDirectoryCatalog,
+            IInitializationServices initializationServices,
+            string scriptName)
+            : this(
+                new CommonLoggingLogProvider(logger),
+                overrides,
+                console,
+                scriptEngineType,
+                scriptExecutorType,
+                replType,
+                initDirectoryCatalog,
+                initializationServices,
+                scriptName)
+        {
+        }
+
         public RuntimeServices(
             ILogProvider logProvider,
             IDictionary<Type, object> overrides,

--- a/src/ScriptCs.Hosting/ScriptConsoleLogger.cs
+++ b/src/ScriptCs.Hosting/ScriptConsoleLogger.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using ScriptCs.Contracts;
+using LogLevel = ScriptCs.Contracts.LogLevel;
+
+namespace ScriptCs.Hosting
+{
+    [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+    public class ScriptConsoleLogger : Common.Logging.Factory.AbstractLogger
+    {
+        private readonly LogLevel _consoleLogLevel;
+        private readonly IConsole _console;
+        private readonly Common.Logging.ILog _log;
+        private readonly Dictionary<Common.Logging.LogLevel, ConsoleColor> colors =
+            new Dictionary<Common.Logging.LogLevel, ConsoleColor>
+            {
+                { Common.Logging.LogLevel.Fatal, ConsoleColor.Red },
+                { Common.Logging.LogLevel.Error, ConsoleColor.DarkRed },
+                { Common.Logging.LogLevel.Warn, ConsoleColor.DarkYellow },
+                { Common.Logging.LogLevel.Info, ConsoleColor.Gray },
+                { Common.Logging.LogLevel.Debug, ConsoleColor.DarkGray },
+                { Common.Logging.LogLevel.Trace, ConsoleColor.DarkMagenta },
+            };
+
+        public ScriptConsoleLogger(LogLevel consoleLogLevel, IConsole console, Common.Logging.ILog log)
+        {
+            Guard.AgainstNullArgument("console", console);
+            Guard.AgainstNullArgument("log", log);
+
+            _consoleLogLevel = consoleLogLevel;
+            _console = console;
+            _log = log;
+        }
+
+        public override bool IsFatalEnabled
+        {
+            get { return true; }
+        }
+
+        public override bool IsErrorEnabled
+        {
+            get { return true; }
+        }
+
+        public override bool IsWarnEnabled
+        {
+            get { return true; }
+        }
+
+        public override bool IsInfoEnabled
+        {
+            get { return _log.IsInfoEnabled || _consoleLogLevel != LogLevel.Error; }
+        }
+
+        public override bool IsDebugEnabled
+        {
+            get { return _log.IsDebugEnabled || _consoleLogLevel == LogLevel.Debug || _consoleLogLevel == LogLevel.Trace; }
+        }
+
+        public override bool IsTraceEnabled
+        {
+            get { return _log.IsTraceEnabled || _consoleLogLevel == LogLevel.Trace; }
+        }
+
+        protected override void WriteInternal(Common.Logging.LogLevel level, object message, Exception exception)
+        {
+            Guard.AgainstNullArgument("message", message);
+
+            var consoleLog = false;
+            switch (level)
+            {
+                case Common.Logging.LogLevel.Fatal:
+                    consoleLog = true;
+                    if (_log.IsFatalEnabled)
+                    {
+                        _log.Fatal(message, exception);
+                    }
+
+                    break;
+                case Common.Logging.LogLevel.Error:
+                    consoleLog = true;
+                    if (_log.IsErrorEnabled)
+                    {
+                        _log.Error(message, exception);
+                    }
+
+                    break;
+                case Common.Logging.LogLevel.Warn:
+                    consoleLog = true;
+                    if (_log.IsWarnEnabled)
+                    {
+                        _log.Warn(message, exception);
+                    }
+
+                    break;
+                case Common.Logging.LogLevel.Info:
+                    consoleLog = _consoleLogLevel != LogLevel.Error;
+                    if (_log.IsInfoEnabled)
+                    {
+                        _log.Info(message, exception);
+                    }
+
+                    break;
+                case Common.Logging.LogLevel.Debug:
+                    consoleLog = _consoleLogLevel == LogLevel.Debug || _consoleLogLevel == LogLevel.Trace;
+                    if (_log.IsDebugEnabled)
+                    {
+                        _log.Debug(message, exception);
+                    }
+
+                    break;
+                case Common.Logging.LogLevel.Trace:
+                    consoleLog = _consoleLogLevel == LogLevel.Trace;
+                    if (_log.IsTraceEnabled)
+                    {
+                        _log.Trace(message, exception);
+                    }
+
+                    break;
+            }
+
+            if (consoleLog)
+            {
+                var prefix = level == Common.Logging.LogLevel.Info
+                    ? null
+                    : string.Concat(level.ToString().ToUpperInvariant(), ": ");
+
+                ConsoleColor color;
+                if (!colors.TryGetValue(level, out color))
+                {
+                    color = ConsoleColor.White;
+                }
+
+                var originalColor = _console.ForegroundColor;
+                _console.ForegroundColor = color;
+                try
+                {
+                    _console.WriteLine(string.Concat(prefix, message.ToString()));
+                }
+                finally
+                {
+                    _console.ForegroundColor = originalColor;
+                }
+            }
+        }
+    }
+}

--- a/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
+++ b/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
@@ -42,6 +42,10 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Autofac.Mef.3.0.3\lib\net40\Autofac.Integration.Mef.dll</HintPath>
     </Reference>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
@@ -79,6 +83,7 @@
     <Compile Include="InitializationServices.cs" />
     <Compile Include="IRuntimeServices.cs" />
     <Compile Include="IScriptServicesBuilder.cs" />
+    <Compile Include="LoggerConfigurator.cs" />
     <Compile Include="ModuleConfiguration.cs" />
     <Compile Include="ModuleLoader.cs" />
     <Compile Include="Package\NugetInstallationProvider.cs" />
@@ -89,6 +94,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RuntimeServices.cs" />
     <Compile Include="ScriptConsole.cs" />
+    <Compile Include="ScriptConsoleLogger.cs" />
     <Compile Include="ScriptServicesRegistration.cs" />
     <Compile Include="ScriptServicesBuilder.cs" />
     <Compile Include="ServiceOverrides.cs" />

--- a/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesBuilder.cs
@@ -21,6 +21,22 @@ namespace ScriptCs.Hosting
         private Type _scriptEngineType;
         private bool? _loadScriptPacks;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public ScriptServicesBuilder(
+            IConsole console,
+            Common.Logging.ILog logger,
+            IRuntimeServices runtimeServices = null,
+            ITypeResolver typeResolver = null,
+            IInitializationServices initializationServices = null)
+            : this(
+                console,
+                new CommonLoggingLogProvider(logger),
+                runtimeServices,
+                typeResolver,
+                initializationServices)
+        {
+        }
+
         public ScriptServicesBuilder(
             IConsole console,
             ILogProvider logProvider,

--- a/src/ScriptCs.Hosting/ScriptServicesRegistration.cs
+++ b/src/ScriptCs.Hosting/ScriptServicesRegistration.cs
@@ -12,9 +12,18 @@ namespace ScriptCs.Hosting
         private readonly ILog _log;
         private readonly IDictionary<Type, object> _overrides;
 
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        public Common.Logging.ILog Logger { get; private set; }
+
         public ILogProvider LogProvider
         {
             get { return _logProvider; }
+        }
+
+        [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
+        protected ScriptServicesRegistration(Common.Logging.ILog logger, IDictionary<Type, object> overrides)
+            :this(new CommonLoggingLogProvider(logger), overrides)
+        {
         }
 
         protected ScriptServicesRegistration(ILogProvider logProvider, IDictionary<Type, object> overrides)
@@ -24,6 +33,9 @@ namespace ScriptCs.Hosting
             _overrides = overrides ?? new Dictionary<Type, object>();
             _logProvider = logProvider;
             _log = _logProvider.ForCurrentType();
+#pragma warning disable 618
+            Logger = new ScriptCsLogger(_log);
+#pragma warning restore 618
         }
 
         protected void RegisterOverrideOrDefault<T>(ContainerBuilder builder, Action<ContainerBuilder> registrationAction)

--- a/src/ScriptCs.Hosting/packages.config
+++ b/src/ScriptCs.Hosting/packages.config
@@ -2,6 +2,7 @@
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net45" />
   <package id="Autofac.Mef" version="3.0.3" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -53,6 +53,10 @@
     <ApplicationIcon>..\..\common\Icon.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>

--- a/src/ScriptCs/packages.config
+++ b/src/ScriptCs/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="PowerArgs" version="2.0.5" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -84,6 +84,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />

--- a/test/ScriptCs.Engine.Mono.Tests/ScriptCs.Engine.Mono.Tests.csproj
+++ b/test/ScriptCs.Engine.Mono.Tests/ScriptCs.Engine.Mono.Tests.csproj
@@ -53,6 +53,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Mono.CSharp, Version=4.0.0.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\packages\Mono.CSharp.4.0.0.143\lib\4.5\Mono.CSharp.dll</HintPath>

--- a/test/ScriptCs.Engine.Mono.Tests/packages.config
+++ b/test/ScriptCs.Engine.Mono.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Mono.CSharp" version="4.0.0.143" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />

--- a/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
+++ b/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
@@ -57,6 +57,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>

--- a/test/ScriptCs.Engine.Roslyn.Tests/packages.config
+++ b/test/ScriptCs.Engine.Roslyn.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Roslyn.Compilers.Common" version="1.2.20906.2" targetFramework="net45" />
   <package id="Roslyn.Compilers.CSharp" version="1.2.20906.2" targetFramework="net45" />

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -63,6 +63,10 @@
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>

--- a/test/ScriptCs.Hosting.Tests/packages.config
+++ b/test/ScriptCs.Hosting.Tests/packages.config
@@ -4,6 +4,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />

--- a/test/ScriptCs.Tests/ScriptCs.Tests.csproj
+++ b/test/ScriptCs.Tests/ScriptCs.Tests.csproj
@@ -60,6 +60,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>

--- a/test/ScriptCs.Tests/packages.config
+++ b/test/ScriptCs.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />

--- a/test/ScriptCsMoqCustomization.cs
+++ b/test/ScriptCsMoqCustomization.cs
@@ -1,4 +1,5 @@
-﻿using Moq;
+﻿using System.Collections.Generic;
+using Moq;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoMoq;
 using ScriptCs.Contracts;
@@ -36,6 +37,38 @@ namespace ScriptCs.Tests
             var logProvider = new TestLogProvider();
             fixture.Register(() => logProvider);
             fixture.Register<ILogProvider>(() => logProvider);
+
+            fixture.Register(()=>new AppDomainAssemblyResolver(
+                fixture.Create<ILogProvider>(),
+                fixture.Create<IFileSystem>(),
+                fixture.Create<IAssemblyResolver>(),
+                fixture.Create<IAssemblyUtility>(),
+                fixture.Create<IDictionary<string, AssemblyInfo>>()));
+
+            fixture.Register(()=> new ScriptLibraryComposer(
+                fixture.Create<IFileSystem>(),
+                fixture.Create<IFilePreProcessor>(),
+                fixture.Create<IPackageContainer>(),
+                fixture.Create<IPackageAssemblyResolver>(),
+                fixture.Create<ILogProvider>()));
+
+            fixture.Register(() => new ScriptServices(
+                fixture.Create<IFileSystem>(),
+                fixture.Create<IPackageAssemblyResolver>(),
+                fixture.Create<IScriptExecutor>(),
+                fixture.Create<IRepl>(),
+                fixture.Create<IScriptEngine>(),
+                fixture.Create<IFilePreProcessor>(),
+                fixture.Create<IScriptPackResolver>(),
+                fixture.Create<IPackageInstaller>(),
+                fixture.Create<IObjectSerializer>(),
+                fixture.Create<ILogProvider>(),
+                fixture.Create<IAssemblyResolver>(),
+                fixture.Create<IEnumerable<IReplCommand>>(),
+                fixture.Create<IFileSystemMigrator>(),
+                fixture.Create<IConsole>(),
+                fixture.Create<IInstallationProvider>(),
+                fixture.Create<IScriptLibraryComposer>()));
         }
     }
 }


### PR DESCRIPTION
Fixes #847

This restores all the Common.Logging members as per version 0.14.1.