### PR TITLE
Upgrade to NuGet 2.8.6

### DIFF
--- a/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
+++ b/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
@@ -52,9 +52,8 @@
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core">
+      <HintPath>..\..\packages\NuGet.Core.2.8.6\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />

--- a/src/ScriptCs.Hosting/packages.config
+++ b/src/ScriptCs.Hosting/packages.config
@@ -5,6 +5,6 @@
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />
+  <package id="Nuget.Core" version="2.8.6" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -95,9 +95,8 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core">
+      <HintPath>..\..\packages\NuGet.Core.2.8.6\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="Ploeh.AutoFixture">
       <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -6,7 +6,7 @@
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />
+  <package id="Nuget.Core" version="2.8.6" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -73,9 +73,8 @@
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Core, Version=2.8.60318.667, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\NuGet.Core.2.8.5\lib\net40-Client\NuGet.Core.dll</HintPath>
+    <Reference Include="NuGet.Core">
+      <HintPath>..\..\packages\NuGet.Core.2.8.6\lib\net40-Client\NuGet.Core.dll</HintPath>
     </Reference>
     <Reference Include="Ploeh.AutoFixture">
       <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>

--- a/test/ScriptCs.Hosting.Tests/packages.config
+++ b/test/ScriptCs.Hosting.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="Common.Logging" version="2.1.2" targetFramework="net45" />
   <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
-  <package id="Nuget.Core" version="2.8.5" targetFramework="net45" />
+  <package id="Nuget.Core" version="2.8.6" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />


### PR DESCRIPTION
Do you have any issues with upgrading nuget to version 2.8.6?

I'm unable to restore the current 2.8.5 nuget package with my linux/monodevelop setup!
I suspect there might be some cross-platform issues with that version.