### PR TITLE
Mono: -V switch does not display version Fixes #1055

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ install:
   - nuget restore ./ScriptCs.sln
 
 script:
-  - mkdir artifacts --parents
-  - xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
+  - mkdir -p artifacts/Release/bin
+  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
+  - xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
+  - cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
   - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:UpdateProjectVersions
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:m /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:RestoreCommonVersionInfo
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
+xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
 
 cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
 mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,9 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
-cp src/*/bin/Release/* artifacts/Release/bin/
-mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:UpdateProjectVersions
+xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:m /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:RestoreCommonVersionInfo
 
+cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
+mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -63,7 +63,8 @@
 
   <Target Name="RestoreCommonVersionInfo" AfterTargets="Build" Condition=" Exists('$(CommonVersionInfoPath).bak') ">
     <Delete Files="$(CommonVersionInfoPath)" Condition=" Exists('$(CommonVersionInfoPath)') " />
-    <Move SourceFiles="$(CommonVersionInfoPath).bak" DestinationFiles="$(CommonVersionInfoPath)" />
+    <Copy SourceFiles="$(CommonVersionInfoPath).bak" DestinationFiles="$(CommonVersionInfoPath)" />
+    <Delete Files="$(CommonVersionInfoPath).bak" Condition=" Exists('$(CommonVersionInfoPath).bak') " />
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
- Updating build.sh to call the two versioning build tasks.
- Bringing build.sh xbuild args more in line with build.cmd.
- Hiding irrelevant warnings from cp in build.sh.
- Slight change to the RestoreCommonVersionInfo task to support xbuild.
