### PR TITLE
Added a hotfix which deletes temporary folders created by NuGet

### DIFF
--- a/src/ScriptCs.Hosting/Package/PackageObject.cs
+++ b/src/ScriptCs.Hosting/Package/PackageObject.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Runtime.Versioning;
+using System.Text.RegularExpressions;
 using NuGet;
 
 using ScriptCs.Contracts;
@@ -59,6 +61,22 @@ namespace ScriptCs.Hosting.Package
             var dlls = _package.GetLibFiles().Where(i => i.EffectivePath.EndsWith(Dll) || i.EffectivePath.EndsWith(Exe));
             IEnumerable<IPackageFile> compatibleFiles;
             VersionUtility.TryGetCompatibleItems(frameworkName, dlls, out compatibleFiles);
+
+            // HACK: Delete unnecessary  temporary NuGet files
+            List<string> tempDirectories = new List<string>();
+            foreach (PhysicalPackageFile file in dlls)
+            {
+                var match = Regex.Match(((PhysicalPackageFile)dlls.First()).SourcePath, "(" + Path.Combine(Path.GetTempPath(), "nuget").Replace("\\", "\\\\") + "\\\\[^\\\\]+?)\\\\");
+                tempDirectories.Add(match.Groups[1].Value);
+
+            }
+
+            foreach (string directory in tempDirectories.Distinct())
+            {
+                Directory.Delete(directory, true);
+            }
+
+            // /HACK
 
             return compatibleFiles != null ? compatibleFiles.Select(i => i.Path) : null;
         }

--- a/src/ScriptCs.Hosting/Package/PackageObject.cs
+++ b/src/ScriptCs.Hosting/Package/PackageObject.cs
@@ -67,13 +67,19 @@ namespace ScriptCs.Hosting.Package
             foreach (PhysicalPackageFile file in dlls)
             {
                 var match = Regex.Match(((PhysicalPackageFile)dlls.First()).SourcePath, "(" + Path.Combine(Path.GetTempPath(), "nuget").Replace("\\", "\\\\") + "\\\\[^\\\\]+?)\\\\");
-                tempDirectories.Add(match.Groups[1].Value);
+                if (match.Success && match.Groups.Count > 1)
+                {
+                    tempDirectories.Add(match.Groups[1].Value); 
+                }
 
             }
 
             foreach (string directory in tempDirectories.Distinct())
             {
-                Directory.Delete(directory, true);
+                if (Directory.Exists(directory))
+                {
+                    Directory.Delete(directory, true);
+                }
             }
 
             // /HACK


### PR DESCRIPTION
This fixes #1053 temporarily until NuGet fixes this.
Because the files are not used in any manner (at least I have not found any) they can safely be removed.