### PR TITLE
Openide

### DIFF
--- a/src/ScriptCs.Contracts/IFileSystem.cs
+++ b/src/ScriptCs.Contracts/IFileSystem.cs
@@ -35,6 +35,8 @@ namespace ScriptCs.Contracts
 
         string GetFullPath(string path);
 
+        string TempPath { get; }
+
         string CurrentDirectory { get; set; }
 
         string NewLine { get; }

--- a/src/ScriptCs.Contracts/ProjectItem.cs
+++ b/src/ScriptCs.Contracts/ProjectItem.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace ScriptCs.Contracts
+{
+    public class ProjectItem
+    {
+        public ProjectItem(Guid project, Guid parent)
+        {
+            Project = project;
+            Parent = parent;
+        }
+
+        public Guid Parent { get; private set; }
+        public Guid Project { get; private set; }
+    }
+}

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -105,6 +105,7 @@
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogProviderExtensions.cs" />
     <Compile Include="ModuleAttribute.cs" />
+    <Compile Include="ProjectItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScriptPack.cs" />
     <Compile Include="ScriptPackSession.cs" />

--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -181,6 +181,15 @@ namespace ScriptCs
             return Path.GetFullPath(path);
         }
 
+
+        public virtual string TempPath
+        {
+            get
+            {
+                return Path.GetTempPath();
+            }
+        }
+
         public virtual string HostBin
         {
             get { return AppDomain.CurrentDomain.BaseDirectory; }

--- a/src/ScriptCs.Hosting/DirectoryInfo.cs
+++ b/src/ScriptCs.Hosting/DirectoryInfo.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScriptCs.Hosting
+{
+    public class DirectoryInfo
+    {
+        public DirectoryInfo()
+        {
+            Guid = System.Guid.NewGuid().ToString().ToUpper();
+            Files = new List<string>();
+            Directories = new Dictionary<string, DirectoryInfo>();
+        }
+
+        public string Guid { get; private set; }
+        public string Name { get; set; }
+        public string Path { get; set; }
+        public string FullPath { get; set; }
+        public List<string> Files { get; private set; }
+        public Dictionary<string, DirectoryInfo> Directories { get; private set; }
+    }
+}

--- a/src/ScriptCs.Hosting/DirectoryInfo.cs
+++ b/src/ScriptCs.Hosting/DirectoryInfo.cs
@@ -10,12 +10,12 @@ namespace ScriptCs.Hosting
     {
         public DirectoryInfo()
         {
-            Guid = System.Guid.NewGuid().ToString().ToUpper();
+            Guid = Guid.NewGuid();
             Files = new List<string>();
             Directories = new Dictionary<string, DirectoryInfo>();
         }
 
-        public string Guid { get; private set; }
+        public Guid Guid { get; private set; }
         public string Name { get; set; }
         public string Path { get; set; }
         public string FullPath { get; set; }

--- a/src/ScriptCs.Hosting/IVisualStudioSolution.cs
+++ b/src/ScriptCs.Hosting/IVisualStudioSolution.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace ScriptCs.Contracts
+{
+    public interface IVisualStudioSolution
+    {
+        void AddHeader();
+        void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, string projectGuid);
+        void AddProject(string path, string name, string guid, string[] files);
+        void AddGlobalHeader(string projectGuid);
+        void AddGlobalNestedProjects(IList<Tuple<string, string>> nestedItems);
+        void AddGlobal(string projectGuid, IList<Tuple<string, string>> nestedItems);
+    }
+}

--- a/src/ScriptCs.Hosting/IVisualStudioSolution.cs
+++ b/src/ScriptCs.Hosting/IVisualStudioSolution.cs
@@ -6,10 +6,10 @@ namespace ScriptCs.Contracts
     public interface IVisualStudioSolution
     {
         void AddHeader();
-        void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, string projectGuid);
-        void AddProject(string path, string name, string guid, string[] files);
-        void AddGlobalHeader(string projectGuid);
-        void AddGlobalNestedProjects(IList<Tuple<string, string>> nestedItems);
-        void AddGlobal(string projectGuid, IList<Tuple<string, string>> nestedItems);
+        void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, Guid projectGuid);
+        void AddProject(string path, string name, Guid guid, string[] files);
+        void AddGlobalHeader(Guid projectGuid);
+        void AddGlobalNestedProjects(IList<ProjectItem> nestedItems);
+        void AddGlobal(Guid projectGuid, IList<ProjectItem> nestedItems);
     }
 }

--- a/src/ScriptCs.Hosting/IVisualStudioSolutionWriter.cs
+++ b/src/ScriptCs.Hosting/IVisualStudioSolutionWriter.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Collections.Generic;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.Contracts
+{
+    public interface IVisualStudioSolutionWriter
+    {
+        string WriteSolution(IFileSystem fs, string script, IVisualStudioSolution solution, IList<Tuple<string, string>> nestedItems = null);
+    }
+}

--- a/src/ScriptCs.Hosting/IVisualStudioSolutionWriter.cs
+++ b/src/ScriptCs.Hosting/IVisualStudioSolutionWriter.cs
@@ -6,6 +6,6 @@ namespace ScriptCs.Contracts
 {
     public interface IVisualStudioSolutionWriter
     {
-        string WriteSolution(IFileSystem fs, string script, IVisualStudioSolution solution, IList<Tuple<string, string>> nestedItems = null);
+        string WriteSolution(IFileSystem fs, string script, IVisualStudioSolution solution, IList<ProjectItem> nestedItems = null);
     }
 }

--- a/src/ScriptCs.Hosting/ReplCommands/OpenVSCommand.cs
+++ b/src/ScriptCs.Hosting/ReplCommands/OpenVSCommand.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.Hosting.ReplCommands
+{
+    public class OpenVsCommand : IReplCommand
+    {
+        private readonly IConsole _console;
+        private IVisualStudioSolutionWriter _writer;
+
+        public OpenVsCommand(IConsole console, IVisualStudioSolutionWriter writer)
+        {
+            _console = console;
+            _writer = writer;
+        }
+
+        public object Execute(IRepl repl, object[] args)
+        {
+            if (PlatformID != PlatformID.Win32NT)
+            {
+                _console.WriteLine("Requires Windows 8 or later to run");
+                return null;
+            }
+            var fs = repl.FileSystem;
+            var launcher = _writer.WriteSolution(fs, (string) args[0], new VisualStudioSolution());
+            _console.WriteLine("Opening Visual Studio");
+            LaunchSolution(launcher);
+            return null;
+        }
+
+        protected internal virtual void LaunchSolution(string launcher)
+        {
+            System.Diagnostics.Process.Start(launcher);
+        }
+
+        protected internal virtual PlatformID PlatformID
+        {
+            get { return Environment.OSVersion.Platform; }
+        }
+
+        public string Description
+        {
+            get { return "Opens a script to edit/debug in Visual Studio"; }
+        }
+
+        public string CommandName
+        {
+            get { return "openvs"; }
+        }
+    }
+}

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -134,6 +134,9 @@ namespace ScriptCs.Hosting
             RegisterOverrideOrDefault<IScriptLibraryComposer>(
                 builder, b => b.RegisterType<ScriptLibraryComposer>().As<IScriptLibraryComposer>().SingleInstance());
 
+            RegisterOverrideOrDefault<IVisualStudioSolutionWriter>(
+                builder, b => b.RegisterType<VisualStudioSolutionWriter>().As<IVisualStudioSolutionWriter>().SingleInstance());
+
             if (_initDirectoryCatalog)
             {
                 var fileSystem = _initializationServices.GetFileSystem();

--- a/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
+++ b/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
@@ -62,7 +62,7 @@
     <Reference Include="Common.Logging, Version=2.1.2.0, Culture=neutral, PublicKeyToken=af08829b84f0328e, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Common.Logging.2.1.2\lib\net40\Common.Logging.dll</HintPath>
       <Private>True</Private>
-    </Reference>    
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\common\CommonAssemblyInfo.cs">
@@ -75,6 +75,7 @@
       <Link>Guard.cs</Link>
     </Compile>
     <Compile Include="ColoredConsoleLogProvider.cs" />
+    <Compile Include="DirectoryInfo.cs" />
     <Compile Include="ITypeResolver.cs" />
     <Compile Include="FileConsole.cs" />
     <Compile Include="IInitializationServices.cs" />
@@ -82,6 +83,8 @@
     <Compile Include="InitializationServices.cs" />
     <Compile Include="IRuntimeServices.cs" />
     <Compile Include="IScriptServicesBuilder.cs" />
+    <Compile Include="IVisualStudioSolution.cs" />
+    <Compile Include="IVisualStudioSolutionWriter.cs" />
     <Compile Include="LoggerConfigurator.cs" />
     <Compile Include="ModuleConfiguration.cs" />
     <Compile Include="ModuleLoader.cs" />
@@ -91,6 +94,7 @@
     <Compile Include="Package\PackageInstaller.cs" />
     <Compile Include="Package\PackageObject.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReplCommands\OpenVSCommand.cs" />
     <Compile Include="RuntimeServices.cs" />
     <Compile Include="ScriptConsole.cs" />
     <Compile Include="ScriptConsoleLogger.cs" />
@@ -100,6 +104,8 @@
     <Compile Include="ObjectSerializer.cs" />
     <Compile Include="TypeResolver.cs" />
     <Compile Include="LineEditor.cs" />
+    <Compile Include="VisualStudioSolution.cs" />
+    <Compile Include="VisualStudioSolutionWriter.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/ScriptCs.Hosting/VisualStudioSolution.cs
+++ b/src/ScriptCs.Hosting/VisualStudioSolution.cs
@@ -29,7 +29,7 @@ namespace ScriptCs.Hosting
             _header.AppendLine("MinimumVisualStudioVersion = 10.0.40219.1");
         }
 
-        public void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, string projectGuid)
+        public void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, Guid projectGuid)
         {
             _projects.AppendFormat(@"Project(""{{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}}"") = ""scriptcs"", ""{0}"", ""{{{1}}}""{2}", scriptcsPath, projectGuid, Environment.NewLine);
             _projects.AppendLine("\tProjectSection(DebuggerProjectSystem) = preProject");
@@ -47,7 +47,7 @@ namespace ScriptCs.Hosting
             _projects.AppendLine("EndProject");
         }
 
-        public void AddProject(string path, string name, string guid, string[] files)
+        public void AddProject(string path, string name, Guid guid, string[] files)
         {
             _projects.AppendFormat(@"Project(""{{2150E333-8FDC-42A3-9474-1A3956D46DE8}}"") = ""{0}"", ""{0}"", ""{{{1}}}""{2}", name, guid, Environment.NewLine);
             _projects.AppendLine("\tProjectSection(SolutionItems) = preProject");
@@ -66,7 +66,7 @@ namespace ScriptCs.Hosting
             _projects.AppendLine("EndProject");
         }
 
-        public void AddGlobalHeader(string projectGuid)
+        public void AddGlobalHeader(Guid projectGuid)
         {
             _global.AppendLine  ("Global");
             _global.AppendLine  ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
@@ -80,20 +80,20 @@ namespace ScriptCs.Hosting
             _global.AppendLine  ("\tEndGlobalSection");
         }
 
-        public void AddGlobalNestedProjects(IList<Tuple<string, string>> nestedItems)
+        public void AddGlobalNestedProjects(IList<ProjectItem> nestedItems)
         {
             if (nestedItems.Any())
             {
                 _global.AppendLine("\tGlobalSection(NestedProjects) = preSolution");
                 foreach (var item in nestedItems)
                 {
-                    _global.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", item.Item1, item.Item2, Environment.NewLine);
+                    _global.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", item.Project, item.Parent, Environment.NewLine);
                 }
                 _global.AppendLine("\tEndGlobalSection");
             }
         }
 
-        public void AddGlobal(string projectGuid, IList<Tuple<string, string>> nestedItems)
+        public void AddGlobal(Guid projectGuid, IList<ProjectItem> nestedItems)
         {
             AddGlobalHeader(projectGuid);
             AddGlobalNestedProjects(nestedItems);

--- a/src/ScriptCs.Hosting/VisualStudioSolution.cs
+++ b/src/ScriptCs.Hosting/VisualStudioSolution.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.Hosting
+{
+    public class VisualStudioSolution : IVisualStudioSolution
+    {
+        internal StringBuilder _header;
+        internal StringBuilder _projects;
+        internal StringBuilder _global;
+
+        public VisualStudioSolution()
+        {
+            _header = new StringBuilder();
+            _projects = new StringBuilder();
+            _global = new StringBuilder();
+            AddHeader();
+        }
+
+        public void AddHeader()
+        {
+            _header.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
+            _header.AppendLine("# Visual Studio 2013");
+            _header.AppendLine("VisualStudioVersion = 12.0.30501.0");
+            _header.AppendLine("MinimumVisualStudioVersion = 10.0.40219.1");
+        }
+
+        public void AddScriptcsProject(string scriptcsPath, string workingPath, string args, bool attach, string projectGuid)
+        {
+            _projects.AppendFormat(@"Project(""{{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}}"") = ""scriptcs"", ""{0}"", ""{{{1}}}""{2}", scriptcsPath, projectGuid, Environment.NewLine);
+            _projects.AppendLine("\tProjectSection(DebuggerProjectSystem) = preProject");
+            _projects.AppendLine("\t\tPortSupplier = 00000000-0000-0000-0000-000000000000");
+            _projects.AppendFormat("\t\tExecutable = {0}{1}", scriptcsPath, Environment.NewLine);
+            _projects.AppendLine("\t\tRemoteMachine = localhost");
+            _projects.AppendFormat("\t\tStartingDirectory = {0}{1}", workingPath, Environment.NewLine);
+            _projects.AppendFormat("\t\tArguments = {0}{1}", args, Environment.NewLine);
+            _projects.AppendLine("\t\tEnvironment = Default");
+            _projects.AppendLine("\t\tLaunchingEngine = 00000000-0000-0000-0000-000000000000");
+            _projects.AppendLine("\t\tUseLegacyDebugEngines = No");
+            _projects.AppendLine("\t\tLaunchSQLEngine = No");
+            _projects.AppendFormat("\t\tAttachLaunchAction = {0}{1}", attach == true ? "Yes" : "No", Environment.NewLine);
+            _projects.AppendLine("\tEndProjectSection");
+            _projects.AppendLine("EndProject");
+        }
+
+        public void AddProject(string path, string name, string guid, string[] files)
+        {
+            _projects.AppendFormat(@"Project(""{{2150E333-8FDC-42A3-9474-1A3956D46DE8}}"") = ""{0}"", ""{0}"", ""{{{1}}}""{2}", name, guid, Environment.NewLine);
+            _projects.AppendLine("\tProjectSection(SolutionItems) = preProject");
+            foreach (var file in files)
+            {
+                if (path == null)
+                {
+                    _projects.AppendFormat("\t\t{0} = {0}{1}", file, Environment.NewLine);
+                }
+                else
+                {
+                    _projects.AppendFormat("\t\t{0}\\{1} = {0}\\{1}{2}", path, file, Environment.NewLine);
+                }
+            }
+            _projects.AppendLine("\tEndProjectSection");
+            _projects.AppendLine("EndProject");
+        }
+
+        public void AddGlobalHeader(string projectGuid)
+        {
+            _global.AppendLine  ("Global");
+            _global.AppendLine  ("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
+            _global.AppendLine  ("\t\tDebug|Any CPU = Debug|Any CPU");
+            _global.AppendLine  ("\tEndGlobalSection");
+            _global.AppendLine  ("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
+            _global.AppendFormat("\t\t{{{0}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU{1}", projectGuid, Environment.NewLine);
+            _global.AppendLine  ("\tEndGlobalSection");
+            _global.AppendLine  ("\tGlobalSection(SolutionProperties) = preSolution");
+            _global.AppendLine  ("\t\tHideSolutionNode = FALSE");
+            _global.AppendLine  ("\tEndGlobalSection");
+        }
+
+        public void AddGlobalNestedProjects(IList<Tuple<string, string>> nestedItems)
+        {
+            if (nestedItems.Any())
+            {
+                _global.AppendLine("\tGlobalSection(NestedProjects) = preSolution");
+                foreach (var item in nestedItems)
+                {
+                    _global.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", item.Item1, item.Item2, Environment.NewLine);
+                }
+                _global.AppendLine("\tEndGlobalSection");
+            }
+        }
+
+        public void AddGlobal(string projectGuid, IList<Tuple<string, string>> nestedItems)
+        {
+            AddGlobalHeader(projectGuid);
+            AddGlobalNestedProjects(nestedItems);
+            _global.AppendLine("EndGlobal");
+        }
+
+        public override string ToString()
+        {
+            var solutionBuilder = new StringBuilder();
+            solutionBuilder.Append(_header);
+            solutionBuilder.Append(_projects);
+            solutionBuilder.Append(_global);
+            return solutionBuilder.ToString();
+        }
+    }
+}

--- a/src/ScriptCs.Hosting/VisualStudioSolutionWriter.cs
+++ b/src/ScriptCs.Hosting/VisualStudioSolutionWriter.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScriptCs.Contracts;
+
+namespace ScriptCs.Hosting
+{
+    public class VisualStudioSolutionWriter : IVisualStudioSolutionWriter
+    {
+        internal DirectoryInfo _root; 
+
+        public string WriteSolution(IFileSystem fs, string script, IVisualStudioSolution solution, IList<Tuple<string, string>> nestedItems = null)
+        {
+            if (nestedItems == null)
+            {
+                nestedItems = new List<Tuple<string, string>>();
+            }
+
+            var launcher = Path.Combine(fs.TempPath, "launcher-" + Guid.NewGuid().ToString() + ".sln");
+
+            if (fs.FileExists(launcher))
+            {
+                fs.FileDelete(launcher);
+            }
+
+            var currentDir = fs.CurrentDirectory;
+            var scriptcsPath = Path.Combine(fs.HostBin, "scriptcs.exe");
+            var scriptcsArgs = string.Format("{0} -debug -loglevel info", script);
+            _root = new DirectoryInfo { Name = "Solution Items", FullPath = currentDir};
+            var projectGuid = Guid.NewGuid().ToString().ToUpper();
+
+            solution.AddScriptcsProject(scriptcsPath, currentDir, scriptcsArgs, false, projectGuid);
+            GetDirectoryInfo(fs, currentDir, _root);
+            AddDirectoryProject(solution, fs, _root, null, nestedItems);
+            solution.AddGlobal(projectGuid, nestedItems);
+            fs.WriteToFile(launcher, solution.ToString());
+            return launcher;
+        }
+
+        private void AddDirectoryProject(IVisualStudioSolution solution, IFileSystem fs, DirectoryInfo currentDirectory, string parent, IList<Tuple<string, string>> nestedItems)
+        {
+            solution.AddProject(currentDirectory.FullPath, currentDirectory.Name, currentDirectory.Guid, currentDirectory.Files.ToArray());
+            foreach (DirectoryInfo dir in currentDirectory.Directories.Values)
+            {
+                AddDirectoryProject(solution, fs, dir, currentDirectory.Guid, nestedItems);
+            }
+            if (parent != null)
+            {
+                nestedItems.Add(new Tuple<string, string>(currentDirectory.Guid, parent));
+            }
+        }
+
+        private void GetDirectoryInfo(IFileSystem fs, string currentDir, DirectoryInfo root)
+        {
+            IEnumerable<string> files;
+            var packagesFolder = Path.Combine(currentDir, fs.PackagesFolder);
+            files = fs.EnumerateFilesAndDirectories(currentDir, "*.csx").Where(
+                f => f.StartsWith(packagesFolder).Equals(false));
+
+            var skip = currentDir.Length;
+
+            foreach (var file in files)
+            {
+                var pruned = file.Substring(skip + 1);
+                var segments = pruned.Split(Path.DirectorySeparatorChar);
+                if (segments.Length == 1)
+                {
+                    root.Files.Add(segments[0]);
+                }
+                else
+                {
+                    var currentDirectory = root;
+                    var path = "";
+                    for (int i = 0; i < segments.Length - 1; i++)
+                    {
+                        var segment = segments[i];
+                        path = path + segment + @"\";
+                        if (!currentDirectory.Directories.ContainsKey(segment))
+                        {
+                            var newDirectory = new DirectoryInfo { Name = segment, Path=path, FullPath = Path.GetDirectoryName(file)};
+                            currentDirectory.Directories[segment] = newDirectory;
+                            currentDirectory = newDirectory;
+                        }
+                        else
+                        {
+                            currentDirectory = currentDirectory.Directories[segment];
+                        }
+                    }
+                    currentDirectory.Files.Add(segments[segments.Length - 1]);
+                }
+            }
+        }
+    }
+}

--- a/test/ScriptCs.Hosting.Tests/ReplCommands/OpenVSCommandTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ReplCommands/OpenVSCommandTests.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using ScriptCs.Contracts;
+using ScriptCs.Hosting.ReplCommands;
+using Xunit;
+
+namespace ScriptCs.Hosting.Tests.ReplCommands
+{
+    public class OpenVsCommandTests
+    {
+        public class TheExecuteCommand
+        {
+            private Mock<OpenVsCommand> _mockCommand;
+            private OpenVsCommand _command;
+            private Mock<IConsole> _mockConsole;
+            private Mock<IVisualStudioSolutionWriter> _mockWriter;
+            private Mock<IRepl> _mockRepl;
+
+            public TheExecuteCommand()
+            {
+                _mockConsole = new Mock<IConsole>();
+                _mockWriter = new Mock<IVisualStudioSolutionWriter>();
+                _mockRepl = new Mock<IRepl>();
+                _mockRepl.SetupGet(r => r.FileSystem).Returns(new FileSystem());
+                _mockCommand = new Mock<OpenVsCommand>(_mockConsole.Object, _mockWriter.Object);
+                _mockCommand.Setup(c => c.PlatformID).Returns(PlatformID.Win32NT);
+                _mockCommand.Setup(c => c.LaunchSolution(It.IsAny<string>()));
+                _mockCommand.Protected();
+                _command = _mockCommand.Object;
+            }
+
+            [Fact]
+            public void OutputsAMessageIfNotWindows8()
+            {
+                _mockCommand.Setup(c => c.PlatformID).Returns(PlatformID.MacOSX);
+                _command.Execute(_mockRepl.Object, new object[] {"test.csx"});
+                _mockConsole.Verify(c=>c.WriteLine("Requires Windows 8 or later to run"));
+            }
+
+            [Fact]
+            public void CreatesTheSolution()
+            {
+                _command.Execute(_mockRepl.Object, new object[] {"test.csx"});
+                _mockWriter.Verify(
+                    w =>
+                        w.WriteSolution(It.IsAny<IFileSystem>(), It.IsAny<string>(), It.IsAny<IVisualStudioSolution>(),
+                            It.IsAny<IList<Tuple<string, string>>>()));
+            }
+
+            [Fact]
+            public void LaunchesTheSolution()
+            {
+                _command.Execute(_mockRepl.Object, new object[] { "test.csx" });
+                _mockCommand.Verify(c=>c.LaunchSolution(It.IsAny<string>()));
+            }
+
+        }
+    }
+}

--- a/test/ScriptCs.Hosting.Tests/ReplCommands/OpenVSCommandTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ReplCommands/OpenVSCommandTests.cs
@@ -49,7 +49,7 @@ namespace ScriptCs.Hosting.Tests.ReplCommands
                 _mockWriter.Verify(
                     w =>
                         w.WriteSolution(It.IsAny<IFileSystem>(), It.IsAny<string>(), It.IsAny<IVisualStudioSolution>(),
-                            It.IsAny<IList<Tuple<string, string>>>()));
+                            It.IsAny<IList<ProjectItem>>()));
             }
 
             [Fact]

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -148,6 +148,12 @@ namespace ScriptCs.Hosting.Tests
             }
 
             [Fact]
+            public void ShouldRegisterTheDefaultVisualStudioSolutionWriterIfNoOverride()
+            {
+                _runtimeServices.Container.Resolve<IVisualStudioSolutionWriter>().ShouldNotBeNull();
+            }
+
+            [Fact]
             public void ShouldRegisterTheDefaultLineProcessors()
             {
                 var processors = _runtimeServices.Container.Resolve<IEnumerable<ILineProcessor>>();
@@ -266,6 +272,14 @@ namespace ScriptCs.Hosting.Tests
                 var mock = new Mock<IAssemblyResolver>();
                 _overrides[typeof(IAssemblyResolver)] = mock.Object;
                 _runtimeServices.Container.Resolve<IAssemblyResolver>().ShouldEqual(mock.Object);
+            }
+
+            [Fact]
+            public void ShouldRegisterTheOverriddenVisualStudioSolutionWriter()
+            {
+                var mock = new Mock<IVisualStudioSolutionWriter>();
+                _overrides[typeof (IVisualStudioSolutionWriter)] = mock.Object.GetType();
+                _runtimeServices.Container.Resolve<IVisualStudioSolutionWriter>().ShouldBeType(mock.Object.GetType());
             }
 
             [Fact]
@@ -464,6 +478,8 @@ namespace ScriptCs.Hosting.Tests
                 {
                     throw new NotImplementedException();
                 }
+
+                public string TempPath { get; private set; }
 
                 public string CurrentDirectory
                 {

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -49,8 +49,11 @@
     <Compile Include="ObjectSerializerTests.cs" />
     <Compile Include="PackageInstallerTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ReplCommands\OpenVSCommandTests.cs" />
     <Compile Include="RuntimeServicesTests.cs" />
     <Compile Include="ScriptServicesBuilderTests.cs" />
+    <Compile Include="VisualStudioSolutionTests.cs" />
+    <Compile Include="VisualStudioSolutionWriterTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/test/ScriptCs.Hosting.Tests/VisualStudioSolutionTests.cs
+++ b/test/ScriptCs.Hosting.Tests/VisualStudioSolutionTests.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Should;
+using Xunit;
+using System.IO;
+
+namespace ScriptCs.Hosting.Tests
+{
+    public class VisualStudioSolutionTests
+    {
+        public class TheConstructor
+        {
+            private VisualStudioSolution _solution = new VisualStudioSolution();
+
+            [Fact]
+            public void ShouldInitializeVariables()
+            {
+                _solution._header.ShouldNotBeNull();
+                _solution._projects.ShouldNotBeNull();
+                _solution._global.ShouldNotBeNull();
+            }
+
+            [Fact]
+            public void ShouldAppendTheHeader()
+            {
+                var headerBuilder = new StringBuilder();
+                headerBuilder.AppendLine("Microsoft Visual Studio Solution File, Format Version 12.00");
+                headerBuilder.AppendLine("# Visual Studio 2013");
+                headerBuilder.AppendLine("VisualStudioVersion = 12.0.30501.0");
+                headerBuilder.AppendLine("MinimumVisualStudioVersion = 10.0.40219.1");
+                _solution._header.ToString().ShouldEqual(headerBuilder.ToString());
+            }
+        }
+
+        public class TheAddGlobalHeaderMethod
+        {
+            private string _projectGuid = Guid.NewGuid().ToString();
+            private VisualStudioSolution _builder = new VisualStudioSolution();
+
+            [Fact]
+            public void ShouldAppendTheGlobalHeader()
+            {
+                _builder.AddGlobalHeader(_projectGuid);
+                var globalBuilder = new StringBuilder();
+                globalBuilder.AppendLine("Global");
+                globalBuilder.AppendLine("\tGlobalSection(SolutionConfigurationPlatforms) = preSolution");
+                globalBuilder.AppendLine("\t\tDebug|Any CPU = Debug|Any CPU");
+                globalBuilder.AppendLine("\tEndGlobalSection");
+                globalBuilder.AppendLine("\tGlobalSection(ProjectConfigurationPlatforms) = postSolution");
+                globalBuilder.AppendFormat("\t\t{{{0}}}.Debug|Any CPU.ActiveCfg = Debug|Any CPU{1}", _projectGuid, Environment.NewLine);
+                globalBuilder.AppendLine("\tEndGlobalSection");
+                globalBuilder.AppendLine("\tGlobalSection(SolutionProperties) = preSolution");
+                globalBuilder.AppendLine("\t\tHideSolutionNode = FALSE");
+                globalBuilder.AppendLine("\tEndGlobalSection");
+                globalBuilder.ToString().ShouldEqual(_builder._global.ToString());
+            }
+        }
+
+        public class TheAddGlobalNestedProjectsMethod
+        {
+            [Fact]
+            public void ShouldAppenedGlobalSectionEntriesForEachProject()
+            {
+                var builder = new VisualStudioSolution();
+
+                var nestedItems = new List<Tuple<string, string>>();
+                nestedItems.Add(new Tuple<string, string>("A", "B"));
+                nestedItems.Add(new Tuple<string, string>("B", "C"));
+                builder.AddGlobalNestedProjects(nestedItems);
+                var nestedBuilder = new StringBuilder();
+                nestedBuilder.AppendLine("\tGlobalSection(NestedProjects) = preSolution");
+                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[0].Item1, nestedItems[0].Item2,
+                    Environment.NewLine);
+                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[1].Item1, nestedItems[1].Item2,
+                    Environment.NewLine);
+                nestedBuilder.AppendLine("\tEndGlobalSection");
+                builder._global.ToString().Contains(nestedBuilder.ToString());
+            }
+        }
+
+        public class TheAddScriptcsProjectMethod
+        {
+            private VisualStudioSolution _builder = new VisualStudioSolution();
+            private const string _scriptcsPath = "scriptcs.exe";
+            private const string _workingPath = "working";
+            private const string _args = "test.csx";
+            private const bool _attach = true;
+            private string _projectGuid = Guid.NewGuid().ToString();
+            private string _projects;
+
+            public TheAddScriptcsProjectMethod()
+            {
+                _builder.AddScriptcsProject(_scriptcsPath, _workingPath, _args, _attach, _projectGuid);
+                _projects = _builder._projects.ToString();
+            }
+
+            [Fact]
+            public void ShouldAppendTheScriptcsProjectSection()
+            {
+                var projectBuilder = new StringBuilder();
+
+                projectBuilder.AppendFormat(@"Project(""{{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}}"") = ""scriptcs"", ""{0}"", ""{{{1}}}""{2}", _scriptcsPath, _projectGuid, Environment.NewLine);
+                projectBuilder.AppendLine("\tProjectSection(DebuggerProjectSystem) = preProject");
+                projectBuilder.AppendLine("\t\tPortSupplier = 00000000-0000-0000-0000-000000000000");
+                projectBuilder.AppendFormat("\t\tExecutable = {0}{1}", _scriptcsPath, Environment.NewLine);
+                projectBuilder.AppendLine("\t\tRemoteMachine = localhost");
+                projectBuilder.AppendFormat("\t\tStartingDirectory = {0}{1}", _workingPath, Environment.NewLine);
+                projectBuilder.AppendFormat("\t\tArguments = {0}{1}", _args, Environment.NewLine);
+                projectBuilder.AppendLine("\t\tEnvironment = Default");
+                projectBuilder.AppendLine("\t\tLaunchingEngine = 00000000-0000-0000-0000-000000000000");
+                projectBuilder.AppendLine("\t\tUseLegacyDebugEngines = No");
+                projectBuilder.AppendLine("\t\tLaunchSQLEngine = No");
+                projectBuilder.AppendFormat("\t\tAttachLaunchAction = {0}{1}", _attach ? "Yes" : "No", Environment.NewLine);
+                projectBuilder.AppendLine("\tEndProjectSection");
+                projectBuilder.AppendLine("EndProject");
+                _projects.ShouldEqual(projectBuilder.ToString());
+            }
+
+            [Fact]
+            public void ShouldSetTheProjectElementScriptcsPath()
+            {
+                _projects.Contains(string.Format(@"Project(""{{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}}"") = ""scriptcs"", ""{0}""", _scriptcsPath));
+            }
+
+            [Fact]
+            public void ShouldSetTheExecutable()
+            {
+                _projects.Contains(string.Format("Executable = {0}", _scriptcsPath));
+            }
+
+            [Fact]
+            public void ShouldSetTheStartingDirectory()
+            {
+                _projects.Contains(string.Format("StartingDirectory = {0}", _workingPath));
+            }
+
+            [Fact]
+            public void ShouldSetTheArguements()
+            {
+                _projects.Contains(string.Format("Arguments = {0}", _args));
+            }
+
+            [Fact]
+            public void ShouldSetTheAttachAction()
+            {
+                _projects.Contains(string.Format("AttachLaunchAction = {0}", _attach ? "Yes" : "No"));
+            }
+        }
+
+        public class TheToStringMethod
+        {
+            [Fact]
+            public void BuildsTheSolution()
+            {
+                var builder = new VisualStudioSolution();
+                builder._header = new StringBuilder("A");
+                builder._projects = new StringBuilder("B");
+                builder._global = new StringBuilder("C");
+                var solution = builder.ToString();
+                solution.ShouldEqual("ABC");
+            }
+        }
+    }
+}

--- a/test/ScriptCs.Hosting.Tests/VisualStudioSolutionTests.cs
+++ b/test/ScriptCs.Hosting.Tests/VisualStudioSolutionTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Should;
 using Xunit;
 using System.IO;
+using ScriptCs.Contracts;
 
 namespace ScriptCs.Hosting.Tests
 {
@@ -37,7 +38,7 @@ namespace ScriptCs.Hosting.Tests
 
         public class TheAddGlobalHeaderMethod
         {
-            private string _projectGuid = Guid.NewGuid().ToString();
+            private Guid _projectGuid = Guid.NewGuid();
             private VisualStudioSolution _builder = new VisualStudioSolution();
 
             [Fact]
@@ -66,15 +67,19 @@ namespace ScriptCs.Hosting.Tests
             {
                 var builder = new VisualStudioSolution();
 
-                var nestedItems = new List<Tuple<string, string>>();
-                nestedItems.Add(new Tuple<string, string>("A", "B"));
-                nestedItems.Add(new Tuple<string, string>("B", "C"));
+                var nestedItems = new List<ProjectItem>();
+                var a = Guid.NewGuid();
+                var b = Guid.NewGuid();
+                var c = Guid.NewGuid();
+
+                nestedItems.Add(new ProjectItem(a, b));
+                nestedItems.Add(new ProjectItem(b, c));
                 builder.AddGlobalNestedProjects(nestedItems);
                 var nestedBuilder = new StringBuilder();
                 nestedBuilder.AppendLine("\tGlobalSection(NestedProjects) = preSolution");
-                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[0].Item1, nestedItems[0].Item2,
+                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[0].Project, nestedItems[0].Parent,
                     Environment.NewLine);
-                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[1].Item1, nestedItems[1].Item2,
+                nestedBuilder.AppendFormat("\t\t{{{0}}} = {{{1}}}{2}", nestedItems[1].Project, nestedItems[1].Parent,
                     Environment.NewLine);
                 nestedBuilder.AppendLine("\tEndGlobalSection");
                 builder._global.ToString().Contains(nestedBuilder.ToString());
@@ -88,7 +93,7 @@ namespace ScriptCs.Hosting.Tests
             private const string _workingPath = "working";
             private const string _args = "test.csx";
             private const bool _attach = true;
-            private string _projectGuid = Guid.NewGuid().ToString();
+            private Guid _projectGuid = Guid.NewGuid();
             private string _projects;
 
             public TheAddScriptcsProjectMethod()

--- a/test/ScriptCs.Hosting.Tests/VisualStudioSolutionWriterTests.cs
+++ b/test/ScriptCs.Hosting.Tests/VisualStudioSolutionWriterTests.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Moq;
+using ScriptCs.Contracts;
+using Should;
+using Xunit;
+using Xunit.Extensions;
+
+namespace ScriptCs.Hosting.Tests
+{
+    public class VisualStudioSolutionWriterTests
+    {
+        public class TheWriteSolutionMethod
+        {
+            private Mock<IVisualStudioSolution> _solutionMock;
+            private Mock<IFileSystem> _fsMock;
+            private VisualStudioSolutionWriter _writer;
+            private IList<Tuple<string, string>> _nestedItems;
+            private string _launcher;
+
+            public TheWriteSolutionMethod()
+            {
+                _writer = new VisualStudioSolutionWriter();
+                _solutionMock = new Mock<IVisualStudioSolution>();
+                _fsMock = new Mock<IFileSystem>();
+                _fsMock.SetupGet(fs => fs.PackagesFolder).Returns(@"packages");
+                _fsMock.SetupGet(fs => fs.HostBin).Returns("bin");
+                _fsMock.SetupGet(fs => fs.CurrentDirectory).Returns("root");
+                _fsMock.Setup(fs=>fs.EnumerateFilesAndDirectories(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(new [] {Path.Combine("root","file1.csx"), Path.Combine("root", "child1", "file2.csx"), Path.Combine("root", "child1", "child2", "file3.csx")});
+                _fsMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(false);
+                _fsMock.SetupGet(fs => fs.TempPath).Returns("temp");
+                _nestedItems = new List<Tuple<string, string>>();
+                _launcher = _writer.WriteSolution(_fsMock.Object, "test.csx", _solutionMock.Object, _nestedItems);
+            }
+
+            [Fact]
+            public void ShouldAddTheScriptcsProject()
+            {
+                var scriptcsPath = Path.Combine("bin", "scriptcs.exe");
+                _solutionMock.Verify(fs=>fs.AddScriptcsProject(scriptcsPath, "root", "test.csx -debug -loglevel info", false, It.IsAny<string>()));
+            }
+
+            [Fact]
+            public void ShoulGetDirectoryInfo()
+            {
+                _writer._root.Files.ShouldContain("file1.csx");
+                var child = _writer._root.Directories.Values.First();
+                child.Files.ShouldContain("file2.csx");
+                child = child.Directories.Values.First();
+                child.Files.ShouldContain("file3.csx");
+            }
+
+            [Fact]
+            public void ShouldCallAddDirectoryProjectForChild()
+            {
+                var child1 = _writer._root.Directories.Values.First();
+                var child2 = child1.Directories.Values.First();
+                _nestedItems.Where(i => i.Item1 == child1.Guid).Count().ShouldEqual(1);
+                _nestedItems.Where(i => i.Item1 == child2.Guid).Count().ShouldEqual(1);
+            }
+
+            [Fact]
+            public void ShouldAddGlobal()
+            {
+                _solutionMock.Verify(s=>s.AddGlobal(It.IsAny<string>(), _nestedItems));
+            }
+
+            [Fact]
+            public void ShouldWriteTheSolution()
+            {
+                _fsMock.Verify(fs=>fs.WriteToFile(It.IsAny<string>(), It.IsAny<string>()));
+            }
+
+            [Fact]
+            public void ShouldReturnALauncherInTheTempFolder()
+            {
+                _launcher.ShouldNotBeNull();
+                _launcher.ShouldStartWith("temp");
+            }           
+        }
+    }
+}

--- a/test/ScriptCs.Hosting.Tests/VisualStudioSolutionWriterTests.cs
+++ b/test/ScriptCs.Hosting.Tests/VisualStudioSolutionWriterTests.cs
@@ -19,7 +19,7 @@ namespace ScriptCs.Hosting.Tests
             private Mock<IVisualStudioSolution> _solutionMock;
             private Mock<IFileSystem> _fsMock;
             private VisualStudioSolutionWriter _writer;
-            private IList<Tuple<string, string>> _nestedItems;
+            private IList<ProjectItem> _nestedItems;
             private string _launcher;
 
             public TheWriteSolutionMethod()
@@ -33,7 +33,7 @@ namespace ScriptCs.Hosting.Tests
                 _fsMock.Setup(fs=>fs.EnumerateFilesAndDirectories(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories)).Returns(new [] {Path.Combine("root","file1.csx"), Path.Combine("root", "child1", "file2.csx"), Path.Combine("root", "child1", "child2", "file3.csx")});
                 _fsMock.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(false);
                 _fsMock.SetupGet(fs => fs.TempPath).Returns("temp");
-                _nestedItems = new List<Tuple<string, string>>();
+                _nestedItems = new List<ProjectItem>();
                 _launcher = _writer.WriteSolution(_fsMock.Object, "test.csx", _solutionMock.Object, _nestedItems);
             }
 
@@ -41,7 +41,7 @@ namespace ScriptCs.Hosting.Tests
             public void ShouldAddTheScriptcsProject()
             {
                 var scriptcsPath = Path.Combine("bin", "scriptcs.exe");
-                _solutionMock.Verify(fs=>fs.AddScriptcsProject(scriptcsPath, "root", "test.csx -debug -loglevel info", false, It.IsAny<string>()));
+                _solutionMock.Verify(fs=>fs.AddScriptcsProject(scriptcsPath, "root", "test.csx -debug -loglevel info", false, It.IsAny<Guid>()));
             }
 
             [Fact]
@@ -59,14 +59,14 @@ namespace ScriptCs.Hosting.Tests
             {
                 var child1 = _writer._root.Directories.Values.First();
                 var child2 = child1.Directories.Values.First();
-                _nestedItems.Where(i => i.Item1 == child1.Guid).Count().ShouldEqual(1);
-                _nestedItems.Where(i => i.Item1 == child2.Guid).Count().ShouldEqual(1);
+                _nestedItems.Where(i => i.Project == child1.Guid).Count().ShouldEqual(1);
+                _nestedItems.Where(i => i.Project == child2.Guid).Count().ShouldEqual(1);
             }
 
             [Fact]
             public void ShouldAddGlobal()
             {
-                _solutionMock.Verify(s=>s.AddGlobal(It.IsAny<string>(), _nestedItems));
+                _solutionMock.Verify(s=>s.AddGlobal(It.IsAny<Guid>(), _nestedItems));
             }
 
             [Fact]

--- a/test/ScriptCs.Tests/ScriptCs.Tests.csproj
+++ b/test/ScriptCs.Tests/ScriptCs.Tests.csproj
@@ -105,6 +105,7 @@
       <Name>ScriptCs</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />


### PR DESCRIPTION
Sending the PR to give visibility and get some other eyes on it. Unit tests are still missing.

This introduces a new `:openvs` REPL command which creates a debuggable solution for scripts and then launches Visual Studio. You get full debugger support, step through, watches, etc!

Essentially it automates the approach [here] (https://github.com/scriptcs/scriptcs/wiki/Debugging-a-script) which @dschenkelman came up with. When you run the command, it will grab all scripts in the folder (including sub-folders) of the script you specified and add them to the solution.

Below you can see a screenshot of debugging a script in VS 2015 after running the command.

![screen shot 2015-12-26 at 3 10 51 pm](https://cloud.githubusercontent.com/assets/141124/12008239/ead696dc-abe2-11e5-940f-f852a1a558a9.png)

Today this only supports Visual Studio as the project structure which it creates is not supported in VS Code, OR in Xamarin Studio. XS doesn't "seem" to have as rich support for an "exe" style project. I tried hacking the equivalent in using an XBuild project, but that didn't work. For reference, [here](https://gist.github.com/glennblock/ca4685f4679348d427f1) is the .sln created for the screenshot.

A few community requests:
* @jamesmontemagno if you have any ideas on how to do the equiv in Xamarin, I'd appreciate it! 
* @shanselman any chance of getting a flow like this to work in VS Code?
* @mat-mcloughlin Omnisharp Sublime etc?