### PR TITLE
(docs) Added missing opening parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Want to chat? In addition to Twitter, you can find us on [Google Groups](https:/
 * [Damian Schenkelman](http://github.com/dschenkelman) ([@dschenkelman](https://twitter.com/intent/user?screen_name=dschenkelman))
 * [Kristian Hellang](http://github.com/khellang) ([@khellang](https://twitter.com/intent/user?screen_name=khellang))
 * [Adam Ralph](http://github.com/adamralph) ([@adamralph](https://twitter.com/intent/user?screen_name=adamralph))
-* [Paul Bouwer](http://github.com/paulbouwer) [@pbouwer](https://twitter.com/intent/user?screen_name=pbouwer))
+* [Paul Bouwer](http://github.com/paulbouwer) ([@pbouwer](https://twitter.com/intent/user?screen_name=pbouwer))
 
 ## Credits 
 


### PR DESCRIPTION
Happened to notice a missing parenthesis around the name of one of the core committer, so thought I would correct it while I was here :smile: 