### PR TITLE
Adds new -e and --eval options which will immediately execute a script

### DIFF
--- a/src/ScriptCs/Command/CommandFactory.cs
+++ b/src/ScriptCs/Command/CommandFactory.cs
@@ -73,6 +73,22 @@ namespace ScriptCs.Command
                 return explicitReplCommand;
             }
 
+            if (config.Eval != null)
+            {
+                var executeLooseScriptCommand = new ExecuteLooseScriptCommand(
+                    config.Eval,
+                    scriptArgs,
+                    scriptServices.FileSystem,
+                    scriptServices.Executor,
+                    scriptServices.ScriptPackResolver,
+                    scriptServices.LogProvider,
+                    scriptServices.AssemblyResolver,
+                    scriptServices.FileSystemMigrator,
+                    scriptServices.ScriptLibraryComposer);
+
+                return executeLooseScriptCommand;
+            }
+
             if (config.ScriptName != null)
             {
                 var currentDirectory = _fileSystem.CurrentDirectory;

--- a/src/ScriptCs/Command/ICommand.cs
+++ b/src/ScriptCs/Command/ICommand.cs
@@ -11,6 +11,10 @@ namespace ScriptCs.Command
     {
     }
 
+    public interface IExecuteLooseScriptCommand : ICommand
+    {
+    }
+
     public interface ISaveCommand : ICommand
     {
     }

--- a/src/ScriptCs/Config.cs
+++ b/src/ScriptCs/Config.cs
@@ -52,6 +52,8 @@ namespace ScriptCs
 
         public bool Watch { get; set; }
 
+        public string Eval { get; set; }
+
         public static Config Create(ScriptCsArgs commandArgs)
         {
             Guard.AgainstNullArgument("commandArgs", commandArgs);
@@ -96,6 +98,7 @@ namespace ScriptCs
                 Debug = mask.Debug ?? Debug,
                 Repl = mask.Repl ?? Repl,
                 ScriptName = scriptName ?? ScriptName,
+                Eval = mask.Eval ?? Eval,
                 Watch = mask.Watch ?? Watch,
             };
         }

--- a/src/ScriptCs/ConfigMask.cs
+++ b/src/ScriptCs/ConfigMask.cs
@@ -35,6 +35,8 @@ namespace ScriptCs
 
         public string ScriptName { get; set; }
 
+        public string Eval { get; set; }
+
         public bool? Watch { get; set; }
 
         public static ConfigMask Create(ScriptCsArgs args)
@@ -56,6 +58,7 @@ namespace ScriptCs
                 Repl = args.Repl ? (bool?)true : null,
                 Save = args.Save ? (bool?)true : null,
                 ScriptName = args.ScriptName,
+                Eval = args.Eval,
                 Watch = args.Watch ? (bool?)true : null,
             };
         }

--- a/src/ScriptCs/ExecuteScriptCommandBase.cs
+++ b/src/ScriptCs/ExecuteScriptCommandBase.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScriptCs.Command;
+using ScriptCs.Contracts;
+
+namespace ScriptCs
+{
+    public abstract class ExecuteScriptCommandBase
+    {
+        protected readonly string _script;
+        protected readonly IFileSystem _fileSystem;
+        protected readonly IScriptExecutor _scriptExecutor;
+        protected readonly IScriptPackResolver _scriptPackResolver;
+        protected readonly ILog _logger;
+        protected readonly IAssemblyResolver _assemblyResolver;
+        protected readonly IFileSystemMigrator _fileSystemMigrator;
+        protected readonly IScriptLibraryComposer _composer;
+
+        public ExecuteScriptCommandBase(
+            string script,
+            string[] scriptArgs,
+            IFileSystem fileSystem,
+            IScriptExecutor scriptExecutor,
+            IScriptPackResolver scriptPackResolver,
+            ILogProvider logProvider,
+            IAssemblyResolver assemblyResolver,
+            IFileSystemMigrator fileSystemMigrator,
+            IScriptLibraryComposer composer
+            )
+        {
+            Guard.AgainstNullArgument("fileSystem", fileSystem);
+            Guard.AgainstNullArgument("scriptExecutor", scriptExecutor);
+            Guard.AgainstNullArgument("scriptPackResolver", scriptPackResolver);
+            Guard.AgainstNullArgument("logProvider", logProvider);
+            Guard.AgainstNullArgument("assemblyResolver", assemblyResolver);
+            Guard.AgainstNullArgument("fileSystemMigrator", fileSystemMigrator);
+            Guard.AgainstNullArgument("composer", composer);
+
+            _script = script;
+            ScriptArgs = scriptArgs;
+            _fileSystem = fileSystem;
+            _scriptExecutor = scriptExecutor;
+            _scriptPackResolver = scriptPackResolver;
+            _logger = logProvider.ForCurrentType();
+            _assemblyResolver = assemblyResolver;
+            _fileSystemMigrator = fileSystemMigrator;
+            _composer = composer;
+        }
+
+        public string[] ScriptArgs { get; private set; }
+
+        public abstract CommandResult Execute();
+
+        protected CommandResult Inspect(ScriptResult result)
+        {
+            if (result == null)
+            {
+                return CommandResult.Error;
+            }
+
+            if (result.CompileExceptionInfo != null)
+            {
+                var ex = result.CompileExceptionInfo.SourceException;
+                _logger.ErrorException("Script compilation failed.", ex);
+                return CommandResult.Error;
+            }
+
+            if (result.ExecuteExceptionInfo != null)
+            {
+                var ex = result.ExecuteExceptionInfo.SourceException;
+                _logger.ErrorException("Script execution failed.", ex);
+                return CommandResult.Error;
+            }
+
+            if (!result.IsCompleteSubmission)
+            {
+                _logger.Error("The script is incomplete.");
+                return CommandResult.Error;
+            }
+
+            return CommandResult.Success;
+        }
+    }
+}

--- a/src/ScriptCs/ScriptCs.csproj
+++ b/src/ScriptCs/ScriptCs.csproj
@@ -85,8 +85,10 @@
     <Compile Include="..\ScriptCs.Core\Guard.cs">
       <Link>Guard.cs</Link>
     </Compile>
+    <Compile Include="Command\ExecuteLooseScriptCommand.cs" />
     <Compile Include="ConfigMask.cs" />
     <Compile Include="Config.cs" />
+    <Compile Include="ExecuteScriptCommandBase.cs" />
     <Compile Include="ProfileOptimizationShim.cs" />
     <Compile Include="Application.cs" />
     <Compile Include="VersionWriter.cs" />

--- a/src/ScriptCs/ScriptCsArgs.cs
+++ b/src/ScriptCs/ScriptCsArgs.cs
@@ -18,6 +18,10 @@ namespace ScriptCs
         [ArgDescription("Script file name, must be specified first")]
         public string ScriptName { get; set; }
 
+        [ArgShortcut("e")]
+        [ArgDescription("Code to immediately evaluate")]
+        public string Eval { get; set; }
+        
         [ArgShortcut("?")]
         [ArgDescription("Displays help")]
         public bool Help { get; set; }

--- a/test/ScriptCs.Tests.Acceptance/LooseScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/LooseScriptExecution.cs
@@ -1,0 +1,96 @@
+﻿namespace ScriptCs.Tests.Acceptance
+{
+    using System;
+    using System.Reflection;
+    using ScriptCs.Tests.Acceptance.Support;
+    using Should;
+    using Xbehave;
+    using Xunit;
+
+    public static class LooseScriptExecution
+    {
+        [Scenario]
+        [Example(true)]
+        [Example(false)]
+        public static void HelloWorld(bool debug, ScenarioDirectory directory, string output, string[] args, string script)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a hello world script"
+                .f(() =>
+                {
+                    directory = ScenarioDirectory.Create(scenario);
+                    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    {
+                        script = @"Console.WriteLine(""""""Hello World!"""""");";
+                    }
+                    else
+                    {
+                        script = @"'Console.WriteLine(""Hello World!"");'";
+                    }
+                    args = new[] {"-e", script};
+                });
+
+            "When I execute the script with debug set to {0}"
+                .f(() => output = ScriptCsExe.Run(args, debug, directory));
+
+            "Then I see 'Hello World!'"
+                .f(() => output.ShouldContain("Hello World!"));
+        }
+
+        [Scenario]
+        [Example(true)]
+        [Example(false)]
+        public static void ScriptThrowsAnException(bool debug, ScenarioDirectory directory, Exception exception, string[] args, string script)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which throws an exception"
+                .f(() =>
+                {
+                    directory = ScenarioDirectory.Create(scenario);
+                    if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                    {
+                        script = @"""throw new Exception(""""""BOOM!"""""");""";
+                    }
+                    else
+                    {
+                        script = @"'throw new Exception(""BOOM!"");'";
+                    }
+                            
+                    args = new[] {"-e", script};
+                });
+
+            "When I execute the script with debug set to {0}"
+                .f(() => exception = Record.Exception(() => ScriptCsExe.Run(args, debug, directory)));
+
+            "Then scriptcs fails"
+                .f(() => exception.ShouldBeType<ScriptCsException>());
+
+            "And I see the exception message"
+                .f(() =>
+                {
+                    exception.Message.ShouldContain("BOOM!");
+                });
+        }
+
+        [Scenario]
+        public static void ScriptCanAccessEnv(ScenarioDirectory directory, string output, string[] args, string script)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which access Env"
+                .f(() =>
+                {
+                    directory = ScenarioDirectory.Create(scenario);
+                    script = "Console.WriteLine(Env)";
+                    args = new[] {"-e", script};
+                });
+            "When I execute the script"
+                .f(() => output = ScriptCsExe.Run(args, directory));
+
+            "Then the Env object is displayed"
+                .f(() => output.ShouldContain("ScriptCs.ScriptEnvironment"));
+        }
+    }
+}

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -45,6 +45,7 @@
     </Compile>
     <Compile Include="CommandLine.cs" />
     <Compile Include="ImplicitInstallation.cs" />
+    <Compile Include="LooseScriptExecution.cs" />
     <Compile Include="Packages.cs" />
     <Compile Include="Configuration.cs" />
     <Compile Include="ScriptLibraries.cs" />

--- a/test/ScriptCs.Tests.Acceptance/Support/ScriptCsExe.cs
+++ b/test/ScriptCs.Tests.Acceptance/Support/ScriptCsExe.cs
@@ -41,6 +41,11 @@
             return Run(null, true, args, Enumerable.Empty<string>(), directory);
         }
 
+        public static string Run(IEnumerable<string> args, bool debug, ScenarioDirectory directory)
+        {
+            return Run(null, debug, args, Enumerable.Empty<string>(), directory);
+        }
+
         public static string Run(string scriptName, ScenarioDirectory directory)
         {
             return Run(scriptName, true, Enumerable.Empty<string>(), Enumerable.Empty<string>(), directory);

--- a/test/ScriptCs.Tests/CommandFactoryTests.cs
+++ b/test/ScriptCs.Tests/CommandFactoryTests.cs
@@ -63,6 +63,25 @@ namespace ScriptCs.Tests
             }
 
             [Fact]
+            public void ShouldExecuteLooseScriptWhenExecIsPassed()
+            {
+                // Arrange
+                var args = new Config
+                {
+                    AllowPreRelease = false,
+                    PackageName = null,
+                    Eval = "foo"
+                };
+
+                // Act
+                var factory = new CommandFactory(CreateBuilder());
+                var result = factory.CreateCommand(args, new string[0]);
+
+                // Assert
+                result.ShouldImplement<IExecuteLooseScriptCommand>();
+            }            
+
+            [Fact]
             public void ShouldExecuteWhenScriptNameIsPassed()
             {
                 // Arrange

--- a/test/ScriptCs.Tests/ExecuteLooseScriptCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteLooseScriptCommandTests.cs
@@ -1,0 +1,239 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Moq;
+using Ploeh.AutoFixture.Xunit;
+using ScriptCs.Command;
+using ScriptCs.Contracts;
+using ScriptCs.Hosting;
+using Should;
+using Xunit.Extensions;
+
+namespace ScriptCs.Tests
+{
+    public class ExecuteLooseScriptCommandTests
+    {
+        public class ExecuteMethod
+        {
+            [Theory, ScriptCsAutoData]
+            public void LooseScriptExecCommandShouldInvokeWithScriptPassedFromArgs(
+                [Frozen] Mock<IFileSystem> fileSystem,
+                [Frozen] Mock<IScriptExecutor> executor,
+                [Frozen] Mock<IInitializationServices> initializationServices,
+                [Frozen] Mock<IScriptServicesBuilder> servicesBuilder,
+                ScriptServices services)
+            {
+                // arrange
+                var args = new Config { AllowPreRelease = false, PackageName = "", Eval = "foo", };
+
+                initializationServices.Setup(i => i.GetFileSystem()).Returns(fileSystem.Object);
+                servicesBuilder.SetupGet(b => b.InitializationServices).Returns(initializationServices.Object);
+                servicesBuilder.Setup(b => b.Build()).Returns(services);
+
+                var factory = new CommandFactory(servicesBuilder.Object);
+                var sut = factory.CreateCommand(args, new string[0]);
+
+                // act
+                sut.Execute();
+
+                // assert
+                executor.Verify(
+                    i => i.Initialize(
+                        It.IsAny<IEnumerable<string>>(), It.IsAny<IEnumerable<IScriptPack>>()), Times.Once());
+
+                executor.Verify(
+                    i => i.ExecuteScript(It.Is<string>(x => x == "foo"), It.IsAny<string[]>()), Times.Once());
+
+                executor.Verify(
+                    i => i.Terminate(), Times.Once());
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void NonManagedAssembliesAreExcluded(
+                [Frozen] Mock<IFileSystem> fileSystem,
+                [Frozen] Mock<IAssemblyUtility> assemblyUtility,
+                [Frozen] Mock<IScriptExecutor> executor,
+                [Frozen] Mock<IInitializationServices> initializationServices,
+                [Frozen] Mock<IScriptServicesBuilder> servicesBuilder,
+                ScriptServices services)
+            {
+                // arrange
+                const string NonManaged = "non-managed.dll";
+
+                var args = new Config { AllowPreRelease = false, PackageName = "", Eval = "foo", };
+
+                fileSystem.Setup(
+                        x => x.EnumerateFiles(It.IsAny<string>(), It.IsAny<string>(), SearchOption.AllDirectories))
+                    .Returns(new[] { "managed.dll", NonManaged });
+
+                assemblyUtility.Setup(x => x.IsManagedAssembly(It.Is<string>(y => y == NonManaged))).Returns(false);
+                initializationServices.Setup(i => i.GetFileSystem()).Returns(fileSystem.Object);
+                servicesBuilder.SetupGet(b => b.InitializationServices).Returns(initializationServices.Object);
+                servicesBuilder.Setup(b => b.Build()).Returns(services);
+
+                var factory = new CommandFactory(servicesBuilder.Object);
+                var sut = factory.CreateCommand(args, new string[0]);
+
+                // act
+                sut.Execute();
+
+                // assert
+                executor.Verify(
+                    i => i.Initialize(
+                        It.Is<IEnumerable<string>>(x => !x.Contains(NonManaged)), It.IsAny<IEnumerable<IScriptPack>>()),
+                    Times.Once());
+
+                executor.Verify(
+                    i => i.ExecuteScript(It.Is<string>(x => x == "foo"), It.IsAny<string[]>()), Times.Once());
+
+                executor.Verify(
+                    i => i.Terminate(), Times.Once());
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnErrorIfThereIsCompileException(
+                [Frozen] Mock<IFileSystem> fileSystem,
+                [Frozen] Mock<IScriptExecutor> executor,
+                [Frozen] TestLogProvider logProvider,
+                [Frozen] Mock<IInitializationServices> initializationServices,
+                [Frozen] Mock<IScriptServicesBuilder> servicesBuilder,
+                ScriptServices services)
+            {
+                // arrange
+                var args = new Config
+                {
+                    AllowPreRelease = false,
+                    PackageName = "",
+                    Eval = "foo"
+                };
+
+                executor.Setup(i => i.ExecuteScript(It.IsAny<string>(), It.IsAny<string[]>()))
+                    .Returns(new ScriptResult(compilationException: new Exception("test")));
+
+                initializationServices.Setup(i => i.GetFileSystem()).Returns(fileSystem.Object);
+                servicesBuilder.SetupGet(b => b.InitializationServices).Returns(initializationServices.Object);
+                servicesBuilder.Setup(b => b.Build()).Returns(services);
+
+                var factory = new CommandFactory(servicesBuilder.Object);
+                var sut = factory.CreateCommand(args, new string[0]);
+
+                // act
+                var result = sut.Execute();
+
+                // assert
+                result.ShouldEqual(CommandResult.Error);
+                logProvider.Output.ShouldContain("ERROR:");
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnErrorIfThereIsExecutionException(
+                [Frozen] Mock<IFileSystem> fileSystem,
+                [Frozen] Mock<IScriptExecutor> executor,
+                [Frozen] TestLogProvider logProvider,
+                [Frozen] Mock<IInitializationServices> initializationServices,
+                [Frozen] Mock<IScriptServicesBuilder> servicesBuilder,
+                ScriptServices services)
+            {
+                // arrange
+                var args = new Config
+                {
+                    AllowPreRelease = false,
+                    PackageName = "",
+                    Eval = "foo"
+                };
+
+                executor.Setup(i => i.ExecuteScript(It.IsAny<string>(), It.IsAny<string[]>()))
+                    .Returns(new ScriptResult(executionException: new Exception("test")));
+
+                initializationServices.Setup(i => i.GetFileSystem()).Returns(fileSystem.Object);
+                servicesBuilder.SetupGet(b => b.InitializationServices).Returns(initializationServices.Object);
+                servicesBuilder.Setup(b => b.Build()).Returns(services);
+
+                var factory = new CommandFactory(servicesBuilder.Object);
+                var sut = factory.CreateCommand(args, new string[0]);
+
+                // act
+                var result = sut.Execute();
+
+                // assert
+                result.ShouldEqual(CommandResult.Error);
+                logProvider.Output.ShouldContain("ERROR:");
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldReturnErrorIfTheScriptIsIncomplete(
+                [Frozen] Mock<IFileSystem> fileSystem,
+                [Frozen] Mock<IScriptExecutor> executor,
+                [Frozen] TestLogProvider logProvider,
+                [Frozen] Mock<IInitializationServices> initializationServices,
+                [Frozen] Mock<IScriptServicesBuilder> servicesBuilder,
+                ScriptServices services)
+            {
+                // arrange
+                var args = new Config { Eval = "foo" };
+
+                executor.Setup(i => i.ExecuteScript(It.IsAny<string>(), It.IsAny<string[]>()))
+                    .Returns(ScriptResult.Incomplete);
+
+                initializationServices.Setup(i => i.GetFileSystem()).Returns(fileSystem.Object);
+                servicesBuilder.SetupGet(b => b.InitializationServices).Returns(initializationServices.Object);
+                servicesBuilder.Setup(b => b.Build()).Returns(services);
+
+                var factory = new CommandFactory(servicesBuilder.Object);
+                var sut = factory.CreateCommand(args, new string[0]);
+
+                // act
+                var result = sut.Execute();
+
+                // assert
+                result.ShouldEqual(CommandResult.Error);
+                logProvider.Output.ShouldContain("ERROR:");
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void MigratesTheFileSystem(
+                [Frozen] Mock<IFileSystem> fileSystem, [Frozen] Mock<IFileSystemMigrator> fileSystemMigrator)
+            {
+                // arrange
+                var sut = new ExecuteLooseScriptCommand(
+                    null,
+                    null,
+                    fileSystem.Object,
+                    new Mock<IScriptExecutor>().Object,
+                    new Mock<IScriptPackResolver>().Object,
+                    new TestLogProvider(),
+                    new Mock<IAssemblyResolver>().Object,
+                    fileSystemMigrator.Object,
+                    new Mock<IScriptLibraryComposer>().Object);
+
+                // act
+                sut.Execute();
+
+                // assert
+                fileSystemMigrator.Verify(m => m.Migrate(), Times.Once);
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldComposeScripts([Frozen] Mock<IFileSystem> fileSystem, Mock<IScriptLibraryComposer> composer)
+            {
+                var cmd = new ExecuteLooseScriptCommand(
+                    null,
+                    null,
+                    fileSystem.Object,
+                    new Mock<IScriptExecutor>().Object,
+                    new Mock<IScriptPackResolver>().Object,
+                    new TestLogProvider(),
+                    new Mock<IAssemblyResolver>().Object,
+                    new Mock<IFileSystemMigrator>().Object,
+                    composer.Object);
+
+                cmd.Execute();
+
+                composer.Verify(c => c.Compose(It.IsAny<string>(), null));
+            }
+
+
+        }
+    }
+}

--- a/test/ScriptCs.Tests/ScriptCs.Tests.csproj
+++ b/test/ScriptCs.Tests/ScriptCs.Tests.csproj
@@ -44,6 +44,7 @@
       <Link>%(Filename)%(Extension)</Link>
     </Compile>
     <Compile Include="ConfigTests.cs" />
+    <Compile Include="ExecuteLooseScriptCommandTests.cs" />
     <Compile Include="ScriptCsArgsTests.cs" />
     <Compile Include="CleanCommandTests.cs" />
     <Compile Include="CommandFactoryTests.cs" />


### PR DESCRIPTION
This fixes #1085 

Update: _`-e` was chosen to align with the existing *nix precedent. Mono's REPL uses this and node as well. Thanks to @migueldeicaza for the suggestion!_

It adds a new switch for immediately executing loose code. Also adds a new convenience overload to the `ScriptCsExe.Run()` method.

example:

```
scriptcs -e 'Console.WriteLine("""Hello from scriptcs""");'
```

_Note_: Depending on the shell you use you may have to jump through different hoops for passing spaces / quoted strings. The example is using Powershell. To do this from the cmd prompt you would use:

```
scriptcs -e 'Console.WriteLine(\"\"\"Hello from scriptcs\"\"\");'
```
