### PR TITLE
ChocolateyInstall.ps1 should not restore Roslyn packages

### DIFF
--- a/src/ScriptCs/Properties/chocolateyInstall.ps1
+++ b/src/ScriptCs/Properties/chocolateyInstall.ps1
@@ -1,18 +1,5 @@
 ﻿try {
     $tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-    $nuget = "$env:ChocolateyInstall\ChocolateyInstall\nuget"
-    $nugetPath = "$tools\nugets"
-
-    Write-Host "Retrieving NuGet dependencies..." -ForegroundColor DarkYellow
-
-    $dependencies = @{
-        "Roslyn.Compilers.CSharp" = "1.2.20906.2";
-    }
-
-    $dependencies.GetEnumerator() | %{ &nuget install $_.Name -version $_.Value -o $nugetPath }
-
-    Get-ChildItem $nugetPath -Filter "*.dll" -Recurse | %{ Copy-Item $_.FullName $tools -Force }
-    Remove-Item $nugetPath -Recurse -Force
 
     if (Test-Path "$tools\..\lib") {
         Remove-Item "$tools\..\lib" -Recurse -Force

--- a/src/ScriptCs/Properties/scriptcs.nuspec
+++ b/src/ScriptCs/Properties/scriptcs.nuspec
@@ -13,9 +13,6 @@
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="System.ComponentModel.Composition" targetFramework="net45" />
     </frameworkAssemblies>
-    <dependencies>
-      <dependency id="NuGet.CommandLine" version="2.5.0" />
-    </dependencies>
   </metadata>
   <files>
     <file src="Properties\chocolateyInstall.ps1" target="tools" />


### PR DESCRIPTION
Previous versions required that Roslyn be restored from NuGet. This is no longer necessary, since we now distribute a more recent release of Roslyn in our package.

Steps to test:
1. Run `build.cmd`.
2. Navigate to `artifacts\Release`.
3. Run `choco install scriptcs -source .`

Scriptcs v0.16.0 should install without error.