### PR TITLE
Custom Printers

### DIFF
--- a/src/ScriptCs.Contracts/IRepl.cs
+++ b/src/ScriptCs.Contracts/IRepl.cs
@@ -1,11 +1,12 @@
 ﻿namespace ScriptCs.Contracts
 {
+    using System;
     using System.Collections.Generic;
 
     public interface IRepl : IScriptExecutor
     {
         Dictionary<string, IReplCommand> Commands { get; }
-
+        void AddCustomPrinter<T>(Func<T, string> printer);
         string Buffer { get; }
     }
 }

--- a/src/ScriptCs.Contracts/IScriptEngine.cs
+++ b/src/ScriptCs.Contracts/IScriptEngine.cs
@@ -10,6 +10,8 @@ namespace ScriptCs.Contracts
 
         string FileName { get; set; }
 
+        IScriptHostFactory ScriptHostFactory { get;}
+
         ScriptResult Execute(
             string code,
             string[] scriptArgs,

--- a/src/ScriptCs.Contracts/IScriptHost.cs
+++ b/src/ScriptCs.Contracts/IScriptHost.cs
@@ -6,5 +6,6 @@ namespace ScriptCs.Contracts
     {
         T Require<T>() where T : IScriptPackContext;
         IScriptEnvironment Env { get; }
+        IRepl Repl { get;}
     }
 }

--- a/src/ScriptCs.Contracts/IScriptHostFactory.cs
+++ b/src/ScriptCs.Contracts/IScriptHostFactory.cs
@@ -2,6 +2,7 @@
 {
     public interface IScriptHostFactory
     {
+        void SetRepl(IRepl repl);
         IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs);
     }
 }

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -14,6 +14,7 @@ namespace ScriptCs
         private readonly IObjectSerializer _serializer;
         private readonly ILog _log;
         private readonly Dictionary<Type, Func<object, string>> _printers = new  Dictionary<Type, Func<object, string>>();
+
         [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
         public Repl(
             string[] scriptArgs,
@@ -75,6 +76,7 @@ namespace ScriptCs
         }
 
         public void AddCustomPrinter<T>(Func<T, string> printer) {
+            Console.WriteLine("adding custom printer");
             _printers[typeof(T)] = x => printer((T) x);
         }
 
@@ -176,10 +178,13 @@ namespace ScriptCs
                 if (result.ReturnValue != null)
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;
-
-                    var serializedResult = _serializer.Serialize(result.ReturnValue);
-
-                    Console.WriteLine(serializedResult);
+                    Func<object, string> printer;
+                    if(_printers.TryGetValue(result.ReturnValue.GetType(), out printer)) {
+                        Console.WriteLine(printer(result.ReturnValue));
+                    } else {
+                        var serializedResult = _serializer.Serialize(result.ReturnValue);
+                        Console.WriteLine(serializedResult);
+                    }
                 }
 
                 Buffer = null;

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -13,7 +13,7 @@ namespace ScriptCs
 
         private readonly IObjectSerializer _serializer;
         private readonly ILog _log;
-
+        private readonly Dictionary<Type, Func<object, string>> _printers = new  Dictionary<Type, Func<object, string>>();
         [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
         public Repl(
             string[] scriptArgs,
@@ -74,9 +74,14 @@ namespace ScriptCs
             Console.Exit();
         }
 
+        public void AddCustomPrinter<T>(Func<T, string> printer) {
+            _printers[typeof(T)] = x => printer((T) x);
+        }
+
         public override ScriptResult Execute(string script, params string[] scriptArgs)
         {
             Guard.AgainstNullArgument("script", script);
+            ScriptEngine.ScriptHostFactory.SetRepl(this);
             try
             {
                 if (script.StartsWith(":"))
@@ -133,7 +138,7 @@ namespace ScriptCs
                 }
 
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                
+
                 InjectScriptLibraries(FileSystem.CurrentDirectory, preProcessResult, ScriptPackSession.State);
 
                 Buffer = (Buffer == null)

--- a/src/ScriptCs.Core/ScriptHost.cs
+++ b/src/ScriptCs.Core/ScriptHost.cs
@@ -6,16 +6,17 @@ namespace ScriptCs
     {
         private readonly IScriptPackManager _scriptPackManager;
 
-        public ScriptHost(IScriptPackManager scriptPackManager, ScriptEnvironment environment)
+        public ScriptHost(IScriptPackManager scriptPackManager, ScriptEnvironment environment, IRepl repl)
         {
             Guard.AgainstNullArgument("scriptPackManager", scriptPackManager);
 
             _scriptPackManager = scriptPackManager;
             Env = environment;
+            Repl = repl;
         }
 
         public IScriptEnvironment Env { get; private set; }
-
+        public IRepl Repl { get; private set; }
         public T Require<T>() where T : IScriptPackContext
         {
             return _scriptPackManager.Get<T>();

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -1,5 +1,5 @@
 ﻿using ScriptCs.Contracts;
-
+using System;
 namespace ScriptCs
 {
     public class ScriptHostFactory : IScriptHostFactory

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -4,9 +4,16 @@ namespace ScriptCs
 {
     public class ScriptHostFactory : IScriptHostFactory
     {
+        private IRepl _repl;
+
+        public void SetRepl(IRepl repl)
+        {
+            _repl = repl;
+        }
+
         public IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs)
         {
-            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs));
+            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs), _repl);
         }
     }
 }

--- a/src/ScriptCs.Engine.Common/CommonScriptEngine.cs
+++ b/src/ScriptCs.Engine.Common/CommonScriptEngine.cs
@@ -29,6 +29,10 @@ namespace ScriptCs.Engine.Common
             set { ScriptOptions = ScriptOptions.WithBaseDirectory(value); }
         }
 
+        public IScriptHostFactory ScriptHostFactory {
+            get { return _scriptHostFactory; }
+        }
+
         public string CacheDirectory { get; set; }
 
         public string FileName { get; set; }
@@ -67,7 +71,7 @@ namespace ScriptCs.Engine.Common
                 var hostType = host.GetType();
 
                 ScriptOptions = ScriptOptions.AddReferences(hostType.Assembly);
-                
+
                 var allNamespaces = namespaces.Union(scriptPackSession.Namespaces).Distinct();
 
                 foreach (var reference in executionReferences.Paths)

--- a/src/ScriptCs.Engine.Mono/MonoHost.cs
+++ b/src/ScriptCs.Engine.Mono/MonoHost.cs
@@ -7,16 +7,10 @@ namespace ScriptCs.Engine.Mono
     public class MonoHost : IScriptHost
     {
         private static ScriptHost _scriptHost;
-        private static IRepl _repl;
 
         public static void SetHost(ScriptHost scriptHost)
         {
             _scriptHost = scriptHost;
-        }
-
-        public static void SetRepl(IRepl repl)
-        {
-            _repl = repl;
         }
 
         public static IScriptEnvironment Env { get { return _scriptHost.Env; } }
@@ -26,7 +20,7 @@ namespace ScriptCs.Engine.Mono
             get { return _scriptHost.Env; }
         }
 
-        public static IRepl Repl { get { return _repl; }}
+        public static IRepl Repl { get { return _scriptHost.Repl; }}
 
         IRepl IScriptHost.Repl
         {

--- a/src/ScriptCs.Engine.Mono/MonoHost.cs
+++ b/src/ScriptCs.Engine.Mono/MonoHost.cs
@@ -7,10 +7,16 @@ namespace ScriptCs.Engine.Mono
     public class MonoHost : IScriptHost
     {
         private static ScriptHost _scriptHost;
+        private static IRepl _repl;
 
         public static void SetHost(ScriptHost scriptHost)
         {
             _scriptHost = scriptHost;
+        }
+
+        public static void SetRepl(IRepl repl)
+        {
+            _repl = repl;
         }
 
         public static IScriptEnvironment Env { get { return _scriptHost.Env; } }
@@ -18,6 +24,13 @@ namespace ScriptCs.Engine.Mono
         IScriptEnvironment IScriptHost.Env
         {
             get { return _scriptHost.Env; }
+        }
+
+        public static IRepl Repl { get { return _repl; }}
+
+        IRepl IScriptHost.Repl
+        {
+            get { return _scriptHost.Repl; }
         }
 
         public static T Require<T>() where T : IScriptPackContext

--- a/src/ScriptCs.Engine.Mono/MonoScriptEngine.cs
+++ b/src/ScriptCs.Engine.Mono/MonoScriptEngine.cs
@@ -22,6 +22,10 @@ namespace ScriptCs.Engine.Mono
         public string CacheDirectory { get; set; }
         public string FileName { get; set; }
 
+        public IScriptHostFactory ScriptHostFactory {
+            get { return _scriptHostFactory; }
+        }
+
         [Obsolete("Support for Common.Logging types was deprecated in version 0.15.0 and will soon be removed.")]
         public MonoScriptEngine(IScriptHostFactory scriptHostFactory, Common.Logging.ILog logger)
             : this(scriptHostFactory, new CommonLoggingLogProvider(logger))

--- a/src/ScriptCs/Command/ExecuteReplCommand.cs
+++ b/src/ScriptCs/Command/ExecuteReplCommand.cs
@@ -65,7 +65,6 @@ namespace ScriptCs.Command
             var scriptPacks = _scriptPackResolver.GetPacks();
 
             _composer.Compose(workingDirectory);
-
             _repl.Initialize(assemblies, scriptPacks, ScriptArgs);
 
             if (!string.IsNullOrWhiteSpace(_scriptName))
@@ -103,7 +102,7 @@ namespace ScriptCs.Command
         private bool ExecuteLine(IRepl repl)
         {
             var prompt = string.IsNullOrWhiteSpace (repl.Buffer) ? "> " : "* ";
-            
+
             try
             {
                 var line = _console.ReadLine(prompt);

--- a/test/ScriptCs.Core.Tests/ScriptHostTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptHostTests.cs
@@ -14,11 +14,12 @@ namespace ScriptCs.Tests
         {
             private readonly Mock<IScriptPackContext> _mockContext = new Mock<IScriptPackContext>();
             private readonly Mock<IScriptPackManager> _mockScriptPackManager = new Mock<IScriptPackManager>();
-            private readonly ScriptHost _scriptHost; 
+            private readonly Mock <IRepl> _repl = new Mock<IRepl>();
+            private readonly ScriptHost _scriptHost;
 
             public TheGetMethod()
             {
-                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0]));
+                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0]), _repl.Object);
                 _mockScriptPackManager.Setup(s => s.Get<IScriptPackContext>()).Returns(_mockContext.Object);
             }
 
@@ -32,13 +33,23 @@ namespace ScriptCs.Tests
 
         public class TheConstructor
         {
+            private readonly Mock <IRepl> _repl = new Mock<IRepl>();
             [Fact]
             public void ShouldSetScriptEnvironment()
             {
                 var environment = new ScriptEnvironment(new string[0]);
-                var scriptHost = new ScriptHost(new Mock<IScriptPackManager>().Object, environment);
+                var scriptHost = new ScriptHost(new Mock<IScriptPackManager>().Object, environment, _repl.Object);
 
                 scriptHost.Env.ShouldEqual(environment);
+            }
+
+            [Fact]
+            public void ShouldSetRepl()
+            {
+                var environment = new ScriptEnvironment(new string[0]);
+                var scriptHost = new ScriptHost(new Mock<IScriptPackManager>().Object, environment, _repl.Object);
+
+                scriptHost.Repl.ShouldEqual(_repl.Object);
             }
         }
     }

--- a/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
@@ -72,7 +72,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 scriptPack.Setup(p => p.Initialize(It.IsAny<IScriptPackSession>()));
                 scriptPack.Setup(p => p.GetContext()).Returns((IScriptPackContext)null);
@@ -94,7 +94,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -116,7 +116,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 // Act
                 engine.Execute(Code, new string[0], new AssemblyReferences(), Enumerable.Empty<string>(), scriptPackSession);
@@ -135,7 +135,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -158,7 +158,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 var code = string.Empty;
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -173,7 +173,7 @@ namespace ScriptCs.Engine.Mono.Tests
 
             // Need to get the compiler ex from mono.
             // Currently the ConsoleReportWriter is swallowing the ex
-            /*            
+            /*
             [Theory, ScriptCsAutoData]
             public void ShouldReturnCompileExceptionIfCodeDoesNotCompile(
                 [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
@@ -211,7 +211,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should compile";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -236,7 +236,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "throw new System.Exception(); //this should throw an Exception";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -259,7 +259,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should not throw an Exception";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -283,7 +283,7 @@ namespace ScriptCs.Engine.Mono.Tests
 
                 // Arrange
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -306,7 +306,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should not return a value";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -333,7 +333,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 var refs = new AssemblyReferences(new[] { "System" });
 
                 scriptHostFactory.Setup(s => s.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns(new ScriptHost(manager.Object, null));
+                    .Returns(new ScriptHost(manager.Object, null, null));
 
                 // Act
                 engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
@@ -28,7 +28,7 @@ namespace ScriptCs.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 scriptPack.Setup(p => p.Initialize(It.IsAny<IScriptPackSession>()));
                 scriptPack.Setup(p => p.GetContext()).Returns((IScriptPackContext)null);
@@ -50,7 +50,7 @@ namespace ScriptCs.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 var session = new SessionState<ScriptState> { Session = CSharpScript.Run("") };
                 scriptPackSession.State[CommonScriptEngine.SessionKey] = session;
@@ -67,7 +67,7 @@ namespace ScriptCs.Tests
             {
                 var scriptHostFactory = new Mock<IScriptHostFactory>();
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
                 // Arrange
                 var engine = new CSharpTestScriptEngine(scriptHostFactory.Object, new TestLogProvider());
@@ -314,7 +314,7 @@ namespace ScriptCs.Tests
             const string Code = "var x = new ScriptCs.Tests.TestMarkerClass();";
 
             scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q), null));
 
             var engine = new CSharpScriptEngine(scriptHostFactory.Object, new TestLogProvider());
             var session = new SessionState<ScriptState> { Session = CSharpScript.Run("") };
@@ -344,7 +344,7 @@ namespace ScriptCs.Tests
             var refs = new AssemblyReferences(new[] { "System" });
 
             scriptHostFactory.Setup(s => s.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                .Returns(new ScriptHost(manager.Object, null));
+                .Returns(new ScriptHost(manager.Object, null, null));
 
             // Act
             engine.Execute(Code, new string[0], refs, Enumerable.Empty<string>(), scriptPackSession);


### PR DESCRIPTION
*This is not intended to be accepted but to act as a point of discussion*

I have implemented here custom pretty printing into scriptcs. I felt something like this after writing it.

![image](https://cloud.githubusercontent.com/assets/381274/13969233/34e9c7ee-f08a-11e5-87e1-5304bdc064f6.png)

Its really ugly. The code does however now work. Here is an example:

```code
greg@clown:~/src/scriptcs$ artifacts/Release/bin/scriptcs -Repl
scriptcs (ctrl-c to exit or :help for help)

> 5 + 5
10
> Repl.AddCustomPrinter<int>(x => "hello greg this is your integer " + x)
adding custom printer
> 5 + 6                                                                   
hello greg this is your integer 11
> Repl.AddCustomPrinter<int>(x => "redefining printer integer is " + x)   
adding custom printer
> 5 + 6                                                                 
redefining printer integer is 11
```

This is a very common thing used in the F# repl. As an example here is a little library that gives you definitions for record types http://fssnip.net/cV so it looks like

```code
// +--------+--------+--------+
// | Label1 | Label2 | Label3 |
// +--------+--------+--------+
// | Value1 | Value2 | Value3 |
// +--------+--------+--------+
// | Value1'| Value2'| Value3'|
// +--------+--------+--------+
```

We make heavy use of this in privateeye

```code
> mostCalledMethods() |> Seq.take 10;;
val it : seq<profilersession.MethodInformation> =

--------------------------------------------------------------------------------
|Name                             |  Called| Total Time|Allocs|  A. Size|Thrown|
--------------------------------------------------------------------------------
|ProcessBlock (byte[],int)        | 3176533| 16402.0126|     0|        0|     0|
|get_Chars (int)                  |  170507|   483.9711|     0|        0|     0|
|get_Rank ()                      |  140403|  2138.1667|     0|        0|     0|
|GetRank (System.Array)           |  140403|   915.1704|     0|        0|     0|
|get_Length ()                    |  131869|  2944.0053|     0|        0|     0|
|__icall_wrapper_mono_object_new_s|   81548|   922.2145| 81548|  3493132|     0|
|CachePropertyInfo (System.Reflect|   78383|   302.0055|     0|        0|     0|
|ReadSegment (byte[],int,int)     |   76117|   416.0591|     0|        0|     0|
|GetAttributeFlagsImpl ()         |   73713|   874.5466|     0|        0|     0|
|GetAttributes (System.RuntimeType|   73713|   291.3721|     0|        0|     0|
--------------------------------------------------------------------------------
```

Now in terms of implementation the one here is a mess but I think it can be improved upon. I don't know all the code that well, In dealing with the dependency graph:

![image](https://cloud.githubusercontent.com/assets/381274/13969503/fb28fe24-f08b-11e5-94e2-ce070b436b1a.png)

I really don't think Repl should be exposed all the way on ScriptHost but it may actually be useful there as you can easily add quite a few other Repl configurations there. An alternative might be to isolate the dependency into ICustomPrinter and put this on ScriptHost.

Some of the rest will likely require some refactoring of dependencies and how they relate. Before just embarking on that I figured it would be worth bringing it up as a discussion.

So first question, does pretty printing seem like a reasonable feature worth following up on?

Second question, how do people see refactoring things to make dependency handling a bit more sane than it is here?

Greg