### PR TITLE
#1143. Char literals does not take escape sequences into account

### DIFF
--- a/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
+++ b/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
@@ -77,11 +77,13 @@ namespace ScriptCs.Engine.Mono.Segmenter.Lexer
                 {
                     previous = _lastChar;
                     _lastChar = Read();
-                    @char += (char)_lastChar;
+					if(_lastChar != Token.Eof)
+                    	@char += (char)_lastChar;
                 } while (!(_lastChar == Token.SingleQuote && previous != Token.EscapeChar)
                     && _lastChar != Token.Eof);
 
-                _lastChar = Read(); //eat
+				if(_lastChar != Token.Eof)
+					_lastChar = Read(); //eat
 
                 return new LexerResult
                 {

--- a/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
+++ b/src/ScriptCs.Engine.Mono/Segmenter/Lexer/ScriptLexer.cs
@@ -72,14 +72,16 @@ namespace ScriptCs.Engine.Mono.Segmenter.Lexer
                 string @char = string.Empty;
                 @char += (char)_lastChar;
 
-                _lastChar = Read();
-                int count = 0;
-                while (count < 2 && _lastChar != Token.Eof)
+                int previous;
+                do
                 {
-                    count++;
-                    @char += (char)_lastChar;
+                    previous = _lastChar;
                     _lastChar = Read();
-                }
+                    @char += (char)_lastChar;
+                } while (!(_lastChar == Token.SingleQuote && previous != Token.EscapeChar)
+                    && _lastChar != Token.Eof);
+
+                _lastChar = Read(); //eat
 
                 return new LexerResult
                 {

--- a/test/ScriptCs.Engine.Mono.Tests/Segmenter/ScriptLexerTests.cs
+++ b/test/ScriptCs.Engine.Mono.Tests/Segmenter/ScriptLexerTests.cs
@@ -130,6 +130,20 @@ namespace ScriptCs.Engine.Mono.Tests.Segmenter
             }
 
             [Fact]
+            public void ShouldIdentifyEscapeSequencesInCharacterLiterals()
+            {
+                const string Code = "\'\\t\'";
+
+                var lexer = new ScriptLexer(Code);
+                var token = lexer.GetToken();
+
+                token.Token.ShouldEqual(Token.Character);
+                token.Start.ShouldEqual(0);
+                token.End.ShouldEqual(4);
+                token.TokenValue.ShouldEqual(Code);
+            }
+
+            [Fact]
             public void ShouldNotFailOnIdentifyingCharactersAsToken()
             {
                 const string Code = "\'A";


### PR DESCRIPTION
See #1143. The single quoted literal (char literal) does not work when there is more than one literal char in the string, which could be true if there are escape sequences involved.

I copied the code from the double quoted literal (string literal) token and this resolves the issue I was seeing. I had to change the code slightly to make the ShouldNotFailOnIdentifyingCharactersAsToken test succeed, as it seems the lexer needs to support some broken input (I am not sure I captured the real intent of the test though).

I added a unit test to ScriptLexerTests to show the case. It should fail without the fix and succeed with the fix
