### PR TITLE
Pretty Printing

### DIFF
--- a/src/ScriptCs.Contracts/IScriptEnvironment.cs
+++ b/src/ScriptCs.Contracts/IScriptEnvironment.cs
@@ -10,5 +10,7 @@ namespace ScriptCs.Contracts
     {
         IReadOnlyList<string> ScriptArgs { get; }
         void AddCustomPrinter<T>(Func<T, string> printer);
+        void Print<T>(T o);
+        void Print(object o);
     }
 }

--- a/src/ScriptCs.Contracts/IScriptEnvironment.cs
+++ b/src/ScriptCs.Contracts/IScriptEnvironment.cs
@@ -9,5 +9,6 @@ namespace ScriptCs.Contracts
     public interface IScriptEnvironment
     {
         IReadOnlyList<string> ScriptArgs { get; }
+        void AddCustomPrinter<T>(Func<T, string> printer);
     }
 }

--- a/src/ScriptCs.Contracts/Printers.cs
+++ b/src/ScriptCs.Contracts/Printers.cs
@@ -3,7 +3,38 @@ using System.Collections.Generic;
 
 namespace ScriptCs.Contracts
 {
-    public class Printers : Dictionary<Type, Func<object, string>>
+    public class Printers
     {
+         private readonly IObjectSerializer _serializer;
+         private readonly Dictionary<Type, Func<object, string>> _dictionary = new Dictionary<Type, Func<object, string>>();
+         public Printers(IObjectSerializer serializer)
+         {
+         	  _serializer = serializer;
+         }
+
+        public void AddCustomPrinter<T>(Func<T, string> printer)
+        {
+            _dictionary[typeof(T)] = x => printer((T) x);
+        }
+
+        private string GetStringFor(Type t,  object obj)
+        {
+           Func<object, string> printer;
+           if(_dictionary.TryGetValue(t, out printer)) {
+                return printer(obj);
+           } else {
+               return _serializer.Serialize(obj);
+           }
+        }
+
+        public string GetStringFor(object obj)
+        {
+           return GetStringFor(obj.GetType(), obj);
+        }
+
+        public string GetStringFor<T>(T obj)
+        {
+           return GetStringFor(typeof(T), obj);
+        }
     }
 }

--- a/src/ScriptCs.Contracts/Printers.cs
+++ b/src/ScriptCs.Contracts/Printers.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace ScriptCs.Contracts
+{
+    public class Printers : Dictionary<Type, Func<object, string>>
+    {
+    }
+}

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -105,6 +105,7 @@
     <Compile Include="LogLevel.cs" />
     <Compile Include="LogProviderExtensions.cs" />
     <Compile Include="ModuleAttribute.cs" />
+    <Compile Include="Printers.cs" />
     <Compile Include="ProjectItem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ScriptPack.cs" />

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -138,7 +138,7 @@ namespace ScriptCs
                 }
 
                 Console.ForegroundColor = ConsoleColor.Cyan;
-                
+
                 InjectScriptLibraries(FileSystem.CurrentDirectory, preProcessResult, ScriptPackSession.State);
 
                 Buffer = (Buffer == null)
@@ -177,13 +177,7 @@ namespace ScriptCs
                 {
                     Console.ForegroundColor = ConsoleColor.Yellow;
 
-                    Func<object, string> printer;
-                    if(_printers.TryGetValue(result.ReturnValue.GetType(), out printer)) {
-                     Console.WriteLine(printer(result.ReturnValue));
-                    } else {
-                     var serializedResult = _serializer.Serialize(result.ReturnValue);
-                     Console.WriteLine(serializedResult);
-                    }
+                    Console.WriteLine(_printers.GetStringFor(result.ReturnValue));
                 }
 
                 Buffer = null;

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -26,12 +26,12 @@ namespace ScriptCs
 
         public void Print(object o)
         {
-            Console.WriteLine(_printers.GetStringFor(o));
+            _console.WriteLine(_printers.GetStringFor(o));
         }
 
         public void Print<T>(T o)
         {
-            Console.WriteLine(_printers.GetStringFor<T>(o));
+            _console.WriteLine(_printers.GetStringFor<T>(o));
         }
 
     }

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -1,15 +1,27 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using ScriptCs.Contracts;
 
 namespace ScriptCs
 {
     public class ScriptEnvironment : IScriptEnvironment
     {
-        public ScriptEnvironment(string[] scriptArgs)
+        private readonly IConsole _console;
+        private readonly Printers _printers;
+
+        public ScriptEnvironment(string[] scriptArgs, IConsole console, Printers printers)
         {
+            _console = console;
+            _printers = printers;
             ScriptArgs = scriptArgs;
         }
 
         public IReadOnlyList<string> ScriptArgs { get; private set; }
+
+        public void AddCustomPrinter<T>(Func<T, string> printer)
+        {
+            _console.WriteLine("Adding custom printer");
+            _printers[typeof(T)] = x => printer((T) x);
+        }
     }
 }

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -20,8 +20,19 @@ namespace ScriptCs
 
         public void AddCustomPrinter<T>(Func<T, string> printer)
         {
-            _console.WriteLine("Adding custom printer");
-            _printers[typeof(T)] = x => printer((T) x);
+            _console.WriteLine("Adding custom printer for " + typeof(T).Name);
+            _printers.AddCustomPrinter<T>(printer);
         }
+
+        public void Print(object o)
+        {
+            Console.WriteLine(_printers.GetStringFor(o));
+        }
+
+        public void Print<T>(T o)
+        {
+            Console.WriteLine(_printers.GetStringFor<T>(o));
+        }
+
     }
 }

--- a/src/ScriptCs.Core/ScriptHost.cs
+++ b/src/ScriptCs.Core/ScriptHost.cs
@@ -1,4 +1,5 @@
-﻿using ScriptCs.Contracts;
+﻿using System;
+using ScriptCs.Contracts;
 
 namespace ScriptCs
 {

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -4,9 +4,18 @@ namespace ScriptCs
 {
     public class ScriptHostFactory : IScriptHostFactory
     {
+        private readonly IConsole _console;
+        private readonly Printers _printers;
+
+        public ScriptHostFactory(IConsole console, Printers printers)
+        {
+            _console = console;
+            _printers = printers;
+        }
+
         public IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs)
         {
-            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs));
+            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs, _console, _printers));
         }
     }
 }

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -85,6 +85,7 @@ namespace ScriptCs.Hosting
             builder.RegisterType(_replType).As<IRepl>().SingleInstance();
             builder.RegisterType<ScriptServices>().SingleInstance();
             builder.RegisterType<Repl>().As<IRepl>().SingleInstance();
+            builder.RegisterType<Printers>().SingleInstance();
 
             RegisterLineProcessors(builder);
             RegisterReplCommands(builder);

--- a/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
@@ -53,7 +53,8 @@ namespace ScriptCs.Tests.ReplCommands
                     composer.Object,
                     console.Object,
                     filePreProcessor.Object,
-                    new List<IReplCommand> { dummyCommand.Object });
+                    new List<IReplCommand> { dummyCommand.Object },
+                    new Printers());
 
                 var cmd = new AliasCommand(console.Object);
 

--- a/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
@@ -54,7 +54,7 @@ namespace ScriptCs.Tests.ReplCommands
                     console.Object,
                     filePreProcessor.Object,
                     new List<IReplCommand> { dummyCommand.Object },
-                    new Printers());
+                    new Printers(serializer.Object));
 
                 var cmd = new AliasCommand(console.Object);
 

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -65,7 +65,7 @@ namespace ScriptCs.Tests
                 mocks.Console.Object,
                 mocks.FilePreProcessor.Object,
                 mocks.ReplCommands.Select(x => x.Object),
-                new Printers());
+                new Printers(mocks.ObjectSerializer.Object));
         }
 
         public class TheConstructor

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -64,7 +64,8 @@ namespace ScriptCs.Tests
                 mocks.ScriptLibraryComposer.Object,
                 mocks.Console.Object,
                 mocks.FilePreProcessor.Object,
-                mocks.ReplCommands.Select(x => x.Object));
+                mocks.ReplCommands.Select(x => x.Object),
+                new Printers());
         }
 
         public class TheConstructor

--- a/test/ScriptCs.Core.Tests/ScriptHostTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptHostTests.cs
@@ -15,11 +15,13 @@ namespace ScriptCs.Tests
             private readonly Mock<IScriptPackContext> _mockContext = new Mock<IScriptPackContext>();
             private readonly Mock<IScriptPackManager> _mockScriptPackManager = new Mock<IScriptPackManager>();
             private readonly Mock<IConsole> _mockConsole = new Mock<IConsole>();
-            private readonly ScriptHost _scriptHost; 
+            private readonly Mock<IObjectSerializer> _mockSerializer = new Mock<IObjectSerializer>();
+
+            private readonly ScriptHost _scriptHost;
 
             public TheGetMethod()
             {
-                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers()));
+                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers(_mockSerializer.Object)));
                 _mockScriptPackManager.Setup(s => s.Get<IScriptPackContext>()).Returns(_mockContext.Object);
             }
 
@@ -35,11 +37,12 @@ namespace ScriptCs.Tests
         {
 
             private readonly Mock<IConsole> _mockConsole = new Mock<IConsole>();
+            private readonly Mock<IObjectSerializer> _mockSerializer = new Mock<IObjectSerializer>();
 
             [Fact]
             public void ShouldSetScriptEnvironment()
             {
-                var environment = new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers());
+                var environment = new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers(_mockSerializer.Object));
                 var scriptHost = new ScriptHost(new Mock<IScriptPackManager>().Object, environment);
 
                 scriptHost.Env.ShouldEqual(environment);

--- a/test/ScriptCs.Core.Tests/ScriptHostTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptHostTests.cs
@@ -14,11 +14,12 @@ namespace ScriptCs.Tests
         {
             private readonly Mock<IScriptPackContext> _mockContext = new Mock<IScriptPackContext>();
             private readonly Mock<IScriptPackManager> _mockScriptPackManager = new Mock<IScriptPackManager>();
+            private readonly Mock<IConsole> _mockConsole = new Mock<IConsole>();
             private readonly ScriptHost _scriptHost; 
 
             public TheGetMethod()
             {
-                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0]));
+                _scriptHost = new ScriptHost(_mockScriptPackManager.Object, new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers()));
                 _mockScriptPackManager.Setup(s => s.Get<IScriptPackContext>()).Returns(_mockContext.Object);
             }
 
@@ -32,10 +33,13 @@ namespace ScriptCs.Tests
 
         public class TheConstructor
         {
+
+            private readonly Mock<IConsole> _mockConsole = new Mock<IConsole>();
+
             [Fact]
             public void ShouldSetScriptEnvironment()
             {
-                var environment = new ScriptEnvironment(new string[0]);
+                var environment = new ScriptEnvironment(new string[0], _mockConsole.Object, new Printers());
                 var scriptHost = new ScriptHost(new Mock<IScriptPackManager>().Object, environment);
 
                 scriptHost.Env.ShouldEqual(environment);

--- a/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
@@ -62,7 +62,12 @@ namespace ScriptCs.Engine.Mono.Tests
         public class TheExecuteMethod
         {
             private IConsole _console = new Mock<IConsole>().Object;
-            private Printers _printers = new Printers();
+            private IObjectSerializer _serializer = new Mock<IObjectSerializer>().Object;
+            private Printers _printers;
+            public TheExecuteMethod()
+            {
+                _printers =  new Printers(_serializer);
+            }
 
             [Theory, ScriptCsAutoData]
             public void ShouldCreateScriptHostWithContexts(
@@ -176,7 +181,7 @@ namespace ScriptCs.Engine.Mono.Tests
 
             // Need to get the compiler ex from mono.
             // Currently the ConsoleReportWriter is swallowing the ex
-            /*            
+            /*
             [Theory, ScriptCsAutoData]
             public void ShouldReturnCompileExceptionIfCodeDoesNotCompile(
                 [Frozen] Mock<IScriptHostFactory> scriptHostFactory,

--- a/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Mono.Tests/MonoScriptEngineTests.cs
@@ -61,6 +61,9 @@ namespace ScriptCs.Engine.Mono.Tests
 
         public class TheExecuteMethod
         {
+            private IConsole _console = new Mock<IConsole>().Object;
+            private Printers _printers = new Printers();
+
             [Theory, ScriptCsAutoData]
             public void ShouldCreateScriptHostWithContexts(
                 [Frozen] Mock<IScriptHostFactory> scriptHostFactory,
@@ -72,7 +75,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 scriptPack.Setup(p => p.Initialize(It.IsAny<IScriptPackSession>()));
                 scriptPack.Setup(p => p.GetContext()).Returns((IScriptPackContext)null);
@@ -94,7 +97,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -116,7 +119,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 // Act
                 engine.Execute(Code, new string[0], new AssemblyReferences(), Enumerable.Empty<string>(), scriptPackSession);
@@ -135,7 +138,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var a = 0;";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -158,7 +161,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 var code = string.Empty;
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -211,7 +214,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should compile";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -236,7 +239,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "throw new System.Exception(); //this should throw an Exception";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -259,7 +262,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should not throw an Exception";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -283,7 +286,7 @@ namespace ScriptCs.Engine.Mono.Tests
 
                 // Arrange
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;
@@ -306,7 +309,7 @@ namespace ScriptCs.Engine.Mono.Tests
                 const string Code = "var theNumber = 42; //this should not return a value";
 
                 scriptHostFactory.Setup(f => f.CreateScriptHost(It.IsAny<IScriptPackManager>(), It.IsAny<string[]>()))
-                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q)));
+                    .Returns<IScriptPackManager, string[]>((p, q) => new ScriptHost(p, new ScriptEnvironment(q, _console, _printers)));
 
                 var session = new SessionState<Evaluator> { Session = new Evaluator(new CompilerContext(new CompilerSettings(), new ConsoleReportPrinter())) };
                 scriptPackSession.State[MonoScriptEngine.SessionKey] = session;

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
@@ -18,8 +18,13 @@ namespace ScriptCs.Tests
         public class TheExecuteMethod
         {
             private IConsole _console = new Mock<IConsole>().Object;
-            private Printers _printers = new Printers();
+            private IObjectSerializer _serializer = new Mock<IObjectSerializer>().Object;
+            private Printers _printers;
 
+            public TheExecuteMethod()
+            {
+                _printers =  new Printers(_serializer);
+            }
             [Theory, ScriptCsAutoData]
             public void ShouldCreateScriptHostWithContexts(
                 [Frozen] Mock<IScriptHostFactory> scriptHostFactory,

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
@@ -16,10 +16,13 @@ namespace ScriptCs.Tests
     {
         public class TheExecuteMethod
         {
+            private IConsole _console = new Mock<IConsole>().Object;
+            private Printers _printers = new Printers();
+
             [Fact]
             public void ShouldExposeExceptionThrownByScriptWhenErrorOccurs()
             {
-                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(), new TestLogProvider());
+                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers), new TestLogProvider());
                 // Arrange
                 var lines = new List<string>
                 {
@@ -43,7 +46,7 @@ namespace ScriptCs.Tests
             [Fact]
             public void ShouldExposeExceptionThrownByCompilation()
             {
-                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(), new TestLogProvider());
+                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers), new TestLogProvider());
 
                 // Arrange
                 var lines = new List<string>

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
@@ -17,7 +17,13 @@ namespace ScriptCs.Tests
         public class TheExecuteMethod
         {
             private IConsole _console = new Mock<IConsole>().Object;
-            private Printers _printers = new Printers();
+            private IObjectSerializer _serializer = new Mock<IObjectSerializer>().Object;
+            private Printers _printers;
+
+            public TheExecuteMethod()
+            {
+                _printers =  new Printers(_serializer);
+            }
 
             [Fact]
             public void ShouldExposeExceptionThrownByScriptWhenErrorOccurs()


### PR DESCRIPTION
Pretty printing support for ScriptCS in REPL

(some of original changes are squashed in @glennblock commit)

```code
$ scriptcs
scriptcs (ctrl-c to exit or :help for help)
> Env.AddCustomPrinter<int>(x => "testing " + x)
Adding custom printer for Int32
> 5
testing 5
>  
```
For running scripts without repl you can also use:

> Env.Print(25)
testing 25

There is also an overload for Print< T >(T obj) that allows for Print<Base>(derived)

@glennblock and I were also discussing the possibility of extracting a Printers interface (a little odd in a test setup to pass the dependecy in).

As state before this is to open up conversation. 
