### PR TITLE
Adding ScriptPath to Env

### DIFF
--- a/src/ScriptCs.Contracts/FileParserContext.cs
+++ b/src/ScriptCs.Contracts/FileParserContext.cs
@@ -19,5 +19,7 @@ namespace ScriptCs.Contracts
         public List<string> LoadedScripts { get; private set; }
 
         public List<string> BodyLines { get; private set; }
+
+        public string ScriptPath { get; set; }
     }
 }

--- a/src/ScriptCs.Contracts/FilePreProcessorResult.cs
+++ b/src/ScriptCs.Contracts/FilePreProcessorResult.cs
@@ -17,6 +17,8 @@ namespace ScriptCs.Contracts
 
         public List<string> References { get; set; }
 
+        public string ScriptPath { get; set; }
+
         public string Code { get; set; }
     }
 }

--- a/src/ScriptCs.Contracts/IScriptEnvironment.cs
+++ b/src/ScriptCs.Contracts/IScriptEnvironment.cs
@@ -13,5 +13,6 @@ namespace ScriptCs.Contracts
         void Print<T>(T o);
         void Print(object o);
         string ScriptPath { get; }
+        string[] LoadedScripts { get; }
     }
 }

--- a/src/ScriptCs.Contracts/IScriptEnvironment.cs
+++ b/src/ScriptCs.Contracts/IScriptEnvironment.cs
@@ -12,5 +12,6 @@ namespace ScriptCs.Contracts
         void AddCustomPrinter<T>(Func<T, string> printer);
         void Print<T>(T o);
         void Print(object o);
+        string ScriptPath { get; }
     }
 }

--- a/src/ScriptCs.Contracts/IScriptInfo.cs
+++ b/src/ScriptCs.Contracts/IScriptInfo.cs
@@ -9,5 +9,6 @@ namespace ScriptCs.Contracts
     public interface IScriptInfo
     {
         string ScriptPath { get; set; }
+        IList<string> LoadedScripts { get; }
     }
 }

--- a/src/ScriptCs.Contracts/IScriptInfo.cs
+++ b/src/ScriptCs.Contracts/IScriptInfo.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ScriptCs.Contracts
+{
+    public interface IScriptInfo
+    {
+        string ScriptPath { get; set; }
+    }
+}

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="App_Packages\LibLog.4.2\LibLog.cs">
-        <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
+      <ExcludeFromStyleCop>true</ExcludeFromStyleCop>
     </Compile>
     <Compile Include="AssemblyReferences.cs" />
     <Compile Include="BehaviorAfterCode.cs" />
@@ -81,6 +81,7 @@
     <Compile Include="IPackageReference.cs" />
     <Compile Include="IRepl.cs" />
     <Compile Include="IScriptEnvironment.cs" />
+    <Compile Include="IScriptInfo.cs" />
     <Compile Include="IScriptLibraryComposer.cs" />
     <Compile Include="IReplCommand.cs" />
     <Compile Include="IReplEngine.cs" />

--- a/src/ScriptCs.Core/DebugScriptExecutor.cs
+++ b/src/ScriptCs.Core/DebugScriptExecutor.cs
@@ -5,8 +5,8 @@ namespace ScriptCs
 {
     public class DebugScriptExecutor : ScriptExecutor
     {
-        public DebugScriptExecutor(IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider, IScriptLibraryComposer composer)
-            : base(fileSystem, filePreProcessor, scriptEngine, logProvider, composer)
+        public DebugScriptExecutor(IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider, IScriptLibraryComposer composer, IScriptInfo scriptInfo)
+            : base(fileSystem, filePreProcessor, scriptEngine, logProvider, composer, scriptInfo)
         {
         }
     }

--- a/src/ScriptCs.Core/FilePreProcessor.cs
+++ b/src/ScriptCs.Core/FilePreProcessor.cs
@@ -54,7 +54,8 @@ namespace ScriptCs
                 Namespaces = context.Namespaces,
                 LoadedScripts = context.LoadedScripts,
                 References = context.References,
-                Code = code
+                Code = code,
+                ScriptPath = context.ScriptPath
             };
         }
 
@@ -80,8 +81,15 @@ namespace ScriptCs
 
             _logger.DebugFormat("Processing {0}...", filename);
 
-            // Add script to loaded collection before parsing to avoid loop.
-            context.LoadedScripts.Add(fullPath);
+            if (context.ScriptPath == null)
+            {
+                context.ScriptPath = fullPath;
+            }
+            else
+            {
+                // Add script to loaded collection before parsing to avoid loop.
+                context.LoadedScripts.Add(fullPath);
+            }
 
             var scriptLines = _fileSystem.ReadFileLines(fullPath).ToList();
 

--- a/src/ScriptCs.Core/Repl.cs
+++ b/src/ScriptCs.Core/Repl.cs
@@ -25,8 +25,9 @@ namespace ScriptCs
             IConsole console,
             IFilePreProcessor filePreProcessor,
             IEnumerable<IReplCommand> replCommands,
-            Printers printers)
-            : base(fileSystem, filePreProcessor, scriptEngine, logProvider, composer)
+            Printers printers,
+            IScriptInfo scriptInfo)
+            : base(fileSystem, filePreProcessor, scriptEngine, logProvider, composer, scriptInfo)
         {
             Guard.AgainstNullArgument("serializer", serializer);
             Guard.AgainstNullArgument("logProvider", logProvider);

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -55,6 +55,7 @@
     <Compile Include="NullScriptLibraryComposer.cs" />
     <Compile Include="ReplCommands\ScriptPacksCommand.cs" />
     <Compile Include="Extensions\TypeExtensions.cs" />
+    <Compile Include="ScriptInfo.cs" />
     <Compile Include="ScriptLibraryComposer.cs" />
     <Compile Include="ScriptLibraryWrapper.cs" />
     <Compile Include="ReplCommands\AliasCommand.cs" />

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -8,11 +8,13 @@ namespace ScriptCs
     {
         private readonly IConsole _console;
         private readonly Printers _printers;
+        private readonly string _scriptPath;
 
-        public ScriptEnvironment(string[] scriptArgs, IConsole console, Printers printers)
+        public ScriptEnvironment(string[] scriptArgs, IConsole console, Printers printers, string scriptPath = null)
         {
             _console = console;
             _printers = printers;
+            _scriptPath = scriptPath;
             ScriptArgs = scriptArgs;
         }
 
@@ -34,5 +36,9 @@ namespace ScriptCs
             _console.WriteLine(_printers.GetStringFor<T>(o));
         }
 
+        public string ScriptPath
+        {
+            get { return _scriptPath; }
+        }
     }
 }

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -9,12 +9,23 @@ namespace ScriptCs
         private readonly IConsole _console;
         private readonly Printers _printers;
         private readonly string _scriptPath;
+        private readonly string[] _loadedScripts;
 
-        public ScriptEnvironment(string[] scriptArgs, IConsole console, Printers printers, string scriptPath = null)
+        public ScriptEnvironment(string[] scriptArgs, IConsole console, Printers printers, string scriptPath = null, string[] loadedScripts = null )
         {
             _console = console;
             _printers = printers;
             _scriptPath = scriptPath;
+
+            if (loadedScripts == null)
+            {
+                _loadedScripts = new string[] {};
+            } 
+            else
+            {
+                _loadedScripts = loadedScripts;
+            }
+            
             ScriptArgs = scriptArgs;
         }
 
@@ -39,6 +50,11 @@ namespace ScriptCs
         public string ScriptPath
         {
             get { return _scriptPath; }
+        }
+
+        public string[] LoadedScripts
+        {
+            get { return _loadedScripts; }
         }
     }
 }

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -164,7 +164,7 @@ namespace ScriptCs
             var result = FilePreProcessor.ProcessFile(path);
 
             ScriptEngine.FileName = Path.GetFileName(path);
-            ScriptInfo.ScriptPath = path;
+            ScriptInfo.ScriptPath = Path.GetFullPath(path);
 
             return EngineExecute(Path.GetDirectoryName(path), scriptArgs, result);
         }
@@ -184,6 +184,10 @@ namespace ScriptCs
             InjectScriptLibraries(workingDirectory, result, ScriptPackSession.State);
             var namespaces = Namespaces.Union(result.Namespaces);
             var references = References.Union(result.References);
+            foreach (var loadedScript in result.LoadedScripts.Skip(1))
+            {
+                ScriptInfo.LoadedScripts.Add(loadedScript);
+            }
             _log.Debug("Starting execution in engine");
             return ScriptEngine.Execute(result.Code, scriptArgs, references, namespaces, ScriptPackSession);
         }

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -14,12 +14,12 @@ namespace ScriptCs
 
         public static readonly string[] DefaultReferences =
         {
-            "System", 
-            "System.Core", 
-            "System.Data", 
-            "System.Data.DataSetExtensions", 
-            "System.Xml", 
-            "System.Xml.Linq", 
+            "System",
+            "System.Core",
+            "System.Data",
+            "System.Data.DataSetExtensions",
+            "System.Xml",
+            "System.Xml.Linq",
             "System.Net.Http",
             "Microsoft.CSharp",
             typeof(ScriptExecutor).Assembly.Location,
@@ -30,8 +30,8 @@ namespace ScriptCs
         {
             "System",
             "System.Collections.Generic",
-            "System.Linq", 
-            "System.Text", 
+            "System.Linq",
+            "System.Text",
             "System.Threading.Tasks",
             "System.IO",
             "System.Net.Http",
@@ -54,9 +54,11 @@ namespace ScriptCs
 
         public IScriptLibraryComposer ScriptLibraryComposer { get; protected set; }
 
+        public IScriptInfo ScriptInfo { get; protected set; }
+
         public ScriptExecutor(
-            IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider)
-            : this(fileSystem, filePreProcessor, scriptEngine, logProvider, new NullScriptLibraryComposer())
+            IFileSystem fileSystem, IFilePreProcessor filePreProcessor, IScriptEngine scriptEngine, ILogProvider logProvider, IScriptInfo scriptInfo)
+            : this(fileSystem, filePreProcessor, scriptEngine, logProvider, new NullScriptLibraryComposer(), scriptInfo)
         {
         }
 
@@ -65,7 +67,8 @@ namespace ScriptCs
             IFilePreProcessor filePreProcessor,
             IScriptEngine scriptEngine,
             ILogProvider logProvider,
-            IScriptLibraryComposer composer)
+            IScriptLibraryComposer composer,
+            IScriptInfo scriptInfo)
         {
             Guard.AgainstNullArgument("fileSystem", fileSystem);
             Guard.AgainstNullArgumentProperty("fileSystem", "BinFolder", fileSystem.BinFolder);
@@ -74,6 +77,7 @@ namespace ScriptCs
             Guard.AgainstNullArgument("scriptEngine", scriptEngine);
             Guard.AgainstNullArgument("logProvider", logProvider);
             Guard.AgainstNullArgument("composer", composer);
+            Guard.AgainstNullArgument("scriptInfo", scriptInfo);
 
             References = new AssemblyReferences(DefaultReferences);
             Namespaces = new ReadOnlyCollection<string>(DefaultNamespaces);
@@ -82,6 +86,7 @@ namespace ScriptCs
             ScriptEngine = scriptEngine;
             _log = logProvider.ForCurrentType();
             ScriptLibraryComposer = composer;
+            ScriptInfo = scriptInfo;
         }
 
         public virtual void ImportNamespaces(params string[] namespaces)
@@ -157,8 +162,9 @@ namespace ScriptCs
         {
             var path = Path.IsPathRooted(script) ? script : Path.Combine(FileSystem.CurrentDirectory, script);
             var result = FilePreProcessor.ProcessFile(path);
-            
+
             ScriptEngine.FileName = Path.GetFileName(path);
+            ScriptInfo.ScriptPath = path;
 
             return EngineExecute(Path.GetDirectoryName(path), scriptArgs, result);
         }
@@ -170,8 +176,8 @@ namespace ScriptCs
         }
 
         protected internal virtual ScriptResult EngineExecute(
-            string workingDirectory, 
-            string[] scriptArgs, 
+            string workingDirectory,
+            string[] scriptArgs,
             FilePreProcessorResult result
         )
         {

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -184,7 +184,8 @@ namespace ScriptCs
             InjectScriptLibraries(workingDirectory, result, ScriptPackSession.State);
             var namespaces = Namespaces.Union(result.Namespaces);
             var references = References.Union(result.References);
-            foreach (var loadedScript in result.LoadedScripts.Skip(1))
+            ScriptInfo.ScriptPath = result.ScriptPath;
+            foreach (var loadedScript in result.LoadedScripts)
             {
                 ScriptInfo.LoadedScripts.Add(loadedScript);
             }

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -6,16 +6,18 @@ namespace ScriptCs
     {
         private readonly IConsole _console;
         private readonly Printers _printers;
-         
-        public ScriptHostFactory(IConsole console, Printers printers)
+        private IScriptInfo _scriptInfo;
+
+        public ScriptHostFactory(IConsole console, Printers printers, IScriptInfo scriptInfo)
         {
             _console = console;
             _printers = printers;
+            _scriptInfo = scriptInfo;
         }
 
         public IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs)
         {
-            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs, _console, _printers));
+            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs, _console, _printers, _scriptInfo.ScriptPath));
         }
     }
 }

--- a/src/ScriptCs.Core/ScriptHostFactory.cs
+++ b/src/ScriptCs.Core/ScriptHostFactory.cs
@@ -1,4 +1,5 @@
-﻿using ScriptCs.Contracts;
+﻿using System.Linq;
+using ScriptCs.Contracts;
 
 namespace ScriptCs
 {
@@ -17,7 +18,7 @@ namespace ScriptCs
 
         public IScriptHost CreateScriptHost(IScriptPackManager scriptPackManager, string[] scriptArgs)
         {
-            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs, _console, _printers, _scriptInfo.ScriptPath));
+            return new ScriptHost(scriptPackManager, new ScriptEnvironment(scriptArgs, _console, _printers, _scriptInfo.ScriptPath, _scriptInfo.LoadedScripts.ToArray()));
         }
     }
 }

--- a/src/ScriptCs.Core/ScriptInfo.cs
+++ b/src/ScriptCs.Core/ScriptInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ScriptCs.Contracts;
+
+namespace ScriptCs
+{
+    public class ScriptInfo : IScriptInfo
+    {
+        public string ScriptPath { get; set; }
+    }
+}

--- a/src/ScriptCs.Core/ScriptInfo.cs
+++ b/src/ScriptCs.Core/ScriptInfo.cs
@@ -9,6 +9,12 @@ namespace ScriptCs
 {
     public class ScriptInfo : IScriptInfo
     {
+        public ScriptInfo()
+        {
+            LoadedScripts = new List<string>();
+        }
+
         public string ScriptPath { get; set; }
-    }
+        public IList<string> LoadedScripts { get; private set; }
+    } 
 }

--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -114,6 +114,8 @@ namespace ScriptCs.Hosting
             RegisterOverrideOrDefault<IVisualStudioSolutionWriter>(
                 builder, b => b.RegisterType<VisualStudioSolutionWriter>().As<IVisualStudioSolutionWriter>().SingleInstance());
 
+            RegisterOverrideOrDefault<IScriptInfo>(builder, b => b.RegisterType<ScriptInfo>().As<IScriptInfo>().SingleInstance());
+
             if (_initDirectoryCatalog)
             {
                 var fileSystem = _initializationServices.GetFileSystem();

--- a/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplCommands/AliasCommandTests.cs
@@ -54,7 +54,8 @@ namespace ScriptCs.Tests.ReplCommands
                     console.Object,
                     filePreProcessor.Object,
                     new List<IReplCommand> { dummyCommand.Object },
-                    new Printers(serializer.Object));
+                    new Printers(serializer.Object),
+                    new ScriptInfo());
 
                 var cmd = new AliasCommand(console.Object);
 

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -65,7 +65,8 @@ namespace ScriptCs.Tests
                 mocks.Console.Object,
                 mocks.FilePreProcessor.Object,
                 mocks.ReplCommands.Select(x => x.Object),
-                new Printers(mocks.ObjectSerializer.Object));
+                new Printers(mocks.ObjectSerializer.Object),
+                new ScriptInfo());
         }
 
         public class TheConstructor

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -590,7 +590,7 @@ namespace ScriptCs.Tests
                 // arrange
                 fileSystem.Setup(fs => fs.FileExists(It.IsAny<string>())).Returns(true);
                 var executor = new ScriptExecutor(
-                    fileSystem.Object, preProcessor.Object, engine.Object, logProvider, composer.Object);
+                    fileSystem.Object, preProcessor.Object, engine.Object, logProvider, composer.Object, new ScriptInfo());
 
                 // act
                 executor.LoadScriptLibraries("");

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptInMemoryEngineTests.cs
@@ -28,7 +28,7 @@ namespace ScriptCs.Tests
             [Fact]
             public void ShouldExposeExceptionThrownByScriptWhenErrorOccurs()
             {
-                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers), new TestLogProvider());
+                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers, new ScriptInfo()), new TestLogProvider());
                 // Arrange
                 var lines = new List<string>
                 {
@@ -52,7 +52,7 @@ namespace ScriptCs.Tests
             [Fact]
             public void ShouldExposeExceptionThrownByCompilation()
             {
-                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers), new TestLogProvider());
+                var scriptEngine = new CSharpScriptInMemoryEngine(new ScriptHostFactory(_console, _printers, new ScriptInfo()), new TestLogProvider());
 
                 // Arrange
                 var lines = new List<string>


### PR DESCRIPTION
# DO NOT MERGE YET

Fix for #225 

Creating this PR so others can review the approach.

This adds a new ScriptInfo class that is set with the path of the file that is executed. Ultimately the path is exposed off of the ambient `Env` property. The approach minimizes signature changes as it depends on ctor injection to get the ScriptInfo class passed around.

@scriptcs/core @rossipedia appreciate your thoughts.

Yes this issue is 2 1/2 years old.....