### PR TITLE
Adding Env.ScriptAssembly

### DIFF
--- a/src/ScriptCs.Contracts/IScriptEnvironment.cs
+++ b/src/ScriptCs.Contracts/IScriptEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -14,5 +15,6 @@ namespace ScriptCs.Contracts
         void Print(object o);
         string ScriptPath { get; }
         string[] LoadedScripts { get; }
+        Assembly ScriptAssembly { get; }
     }
 }

--- a/src/ScriptCs.Core/ScriptEnvironment.cs
+++ b/src/ScriptCs.Core/ScriptEnvironment.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using ScriptCs.Contracts;
 
 namespace ScriptCs
@@ -45,6 +46,19 @@ namespace ScriptCs
         public string[] LoadedScripts
         {
             get { return _scriptInfo.LoadedScripts.ToArray(); }
+        }
+
+        private Assembly _scriptAssembly;
+        public Assembly ScriptAssembly
+        {
+            get
+            {
+                if (_scriptAssembly == null)
+                {
+                    _scriptAssembly = Assembly.GetCallingAssembly();
+                }
+                return _scriptAssembly;
+            }
         }
     }
 }

--- a/src/ScriptCs.Core/ScriptInfo.cs
+++ b/src/ScriptCs.Core/ScriptInfo.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Threading.Tasks;
 using ScriptCs.Contracts;

--- a/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
@@ -1,4 +1,6 @@
-﻿namespace ScriptCs.Tests.Acceptance
+﻿using System.IO;
+
+namespace ScriptCs.Tests.Acceptance
 {
     using System;
     using System.Reflection;
@@ -53,7 +55,7 @@
         {
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
-            "Given a script which access Env"
+            "Given a script which accesses Env"
                 .f(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine(Env)"));
 
@@ -80,5 +82,64 @@
                 .f(() => output.ShouldContain("bar"));
 
         }
+
+        [Scenario]
+        public static void ScriptAssemblyIsSet(ScenarioDirectory directory, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which accesses Env.ScriptAssembly"
+                .f(() => directory = ScenarioDirectory.Create(scenario)
+                    .WriteLine("foo.csx", "Console.WriteLine(Env.ScriptAssembly)"));
+
+            "When I execute the script"
+                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+
+            "Then the Assembly is displayed"
+                .f(() => output.ShouldContain("Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
+
+        }
+
+        [Scenario]
+        public static void ScriptPathIsSet(ScenarioDirectory directory, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which accesses Env.ScriptPath"
+                .f(() => directory = ScenarioDirectory.Create(scenario)
+                    .WriteLine("foo.csx", "Console.WriteLine(Env.ScriptPath)"));
+
+            "When I execute the script"
+                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+
+            "Then the ScriptPath is displayed"
+                .f(() => output.ShouldContain("foo.csx"));
+        }
+
+        [Scenario]
+        public static void LoadedScriptsIsSet(ScenarioDirectory directory, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which loads another script and accesses Env.LoadedScripts"
+                .f(() =>
+                {
+                    directory = ScenarioDirectory.Create(scenario)
+                        .WriteLine(
+                            "foo.csx", "#load bar.csx;" + Environment.NewLine +
+                                       "Console.WriteLine(Env.LoadedScripts.First());"
+                        );
+                    directory.WriteLine("bar.csx", "");
+                });
+                    
+
+            "When I execute the script"
+                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+
+            "Then the loaded script path is displayed"
+                .f(() => output.ShouldContain("bar.csx"));
+        }
+
+
     }
 }


### PR DESCRIPTION
This feature adds a new `Env.ScriptAssembly` and fixes #244. The assembly is accessible in scripts or in the REPL.

