### PR TITLE
Paket directive

### DIFF
--- a/src/ScriptCs.Contracts/FileParserContext.cs
+++ b/src/ScriptCs.Contracts/FileParserContext.cs
@@ -7,14 +7,17 @@ namespace ScriptCs.Contracts
         public FileParserContext()
         {
             Namespaces = new List<string>();
-            References = new List<string>();
+            AssemblyReferences = new List<string>();
             LoadedScripts = new List<string>();
             BodyLines = new List<string>();
+            CustomReferences = new List<string>();
         }
 
         public List<string> Namespaces { get; private set; }
 
-        public List<string> References { get; private set; }
+        public List<string> AssemblyReferences { get; private set; }
+
+        public List<string> CustomReferences { get; private set; } 
 
         public List<string> LoadedScripts { get; private set; }
 

--- a/src/ScriptCs.Contracts/FilePreProcessorResult.cs
+++ b/src/ScriptCs.Contracts/FilePreProcessorResult.cs
@@ -8,14 +8,17 @@ namespace ScriptCs.Contracts
         {
             Namespaces = new List<string>();
             LoadedScripts = new List<string>();
-            References = new List<string>();
+            AssemblyReferences = new List<string>();
+            CustomReferences = new List<string>();
         }
 
         public List<string> Namespaces { get; set; }
 
         public List<string> LoadedScripts { get; set; }
 
-        public List<string> References { get; set; }
+        public List<string> AssemblyReferences { get; set; }
+
+        public List<string> CustomReferences { get; set; } 
 
         public string ScriptPath { get; set; }
 

--- a/src/ScriptCs.Core/Constants.cs
+++ b/src/ScriptCs.Core/Constants.cs
@@ -22,5 +22,7 @@ namespace ScriptCs
         public const string ConfigFilename = "scriptcs.opts";
 
         public const string DefaultRepositoryUrl = "https://nuget.org/api/v2/";
+
+        public const string PaketPrefix = "paket:";
     }
 }

--- a/src/ScriptCs.Core/FilePreProcessor.cs
+++ b/src/ScriptCs.Core/FilePreProcessor.cs
@@ -55,7 +55,8 @@ namespace ScriptCs
             {
                 Namespaces = context.Namespaces,
                 LoadedScripts = context.LoadedScripts,
-                References = context.References,
+                AssemblyReferences = context.AssemblyReferences,
+                CustomReferences = context.CustomReferences,
                 Code = code,
                 ScriptPath = context.ScriptPath
             };

--- a/src/ScriptCs.Core/ReferenceLineProcessor.cs
+++ b/src/ScriptCs.Core/ReferenceLineProcessor.cs
@@ -38,11 +38,11 @@ namespace ScriptCs
 
             var expandedArgument = Environment.ExpandEnvironmentVariables(argument);
 
-            if (argument.ToLower().Contains("paket:"))
+            if (argument.ToLower().StartsWith(Constants.PaketPrefix))
             {
-                if (!context.References.Contains(argument))
+                if (!context.CustomReferences.Contains(argument))
                 {
-                    context.References.Add(argument);
+                    context.CustomReferences.Add(argument);
                 }
                 return true;
             }
@@ -50,9 +50,9 @@ namespace ScriptCs
             var referencePath = _fileSystem.GetFullPath(expandedArgument);
             var referencePathOrName = _fileSystem.FileExists(referencePath) ? referencePath : argument;
 
-            if (!string.IsNullOrWhiteSpace(referencePathOrName) && !context.References.Contains(referencePathOrName))
+            if (!string.IsNullOrWhiteSpace(referencePathOrName) && !context.AssemblyReferences.Contains(referencePathOrName))
             {
-                context.References.Add(referencePathOrName);
+                context.AssemblyReferences.Add(referencePathOrName);
             }
 
             return true;

--- a/src/ScriptCs.Core/ReferenceLineProcessor.cs
+++ b/src/ScriptCs.Core/ReferenceLineProcessor.cs
@@ -32,11 +32,22 @@ namespace ScriptCs
         protected override bool ProcessLine(IFileParser parser, FileParserContext context, string line)
         {
             Guard.AgainstNullArgument("context", context);
-
+            
             var argument = GetDirectiveArgument(line);
-            var assemblyPath = Environment.ExpandEnvironmentVariables(argument);
 
-            var referencePath = _fileSystem.GetFullPath(assemblyPath);
+
+            var expandedArgument = Environment.ExpandEnvironmentVariables(argument);
+
+            if (argument.ToLower().Contains("paket:"))
+            {
+                if (!context.References.Contains(argument))
+                {
+                    context.References.Add(argument);
+                }
+                return true;
+            }
+
+            var referencePath = _fileSystem.GetFullPath(expandedArgument);
             var referencePathOrName = _fileSystem.FileExists(referencePath) ? referencePath : argument;
 
             if (!string.IsNullOrWhiteSpace(referencePathOrName) && !context.References.Contains(referencePathOrName))

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -113,6 +113,10 @@
       <Project>{6049e205-8b5f-4080-b023-70600e51fd64}</Project>
       <Name>ScriptCs.Contracts</Name>
     </ProjectReference>
+    <ProjectReference Include="..\ScriptCs.PaketDirective\ScriptCs.PaketDirective.fsproj">
+      <Project>{370e27b3-a2b4-4a8a-8992-49252b7175c1}</Project>
+      <Name>ScriptCs.PaketDirective</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -183,7 +183,7 @@ namespace ScriptCs
         {
             InjectScriptLibraries(workingDirectory, result, ScriptPackSession.State);
             var namespaces = Namespaces.Union(result.Namespaces);
-            var references = References.Union(result.References);
+            var references = References.Union(result.AssemblyReferences);
             ScriptInfo.ScriptPath = result.ScriptPath;
             foreach (var loadedScript in result.LoadedScripts)
             {
@@ -214,7 +214,7 @@ namespace ScriptCs
                 result.Code = scriptLibrariesPreProcessorResult.Code + Environment.NewLine
                               + "Env.Initialize();" + Environment.NewLine
                               + result.Code;
-                result.References.AddRange(scriptLibrariesPreProcessorResult.References);
+                result.AssemblyReferences.AddRange(scriptLibrariesPreProcessorResult.AssemblyReferences);
                 result.Namespaces.AddRange(scriptLibrariesPreProcessorResult.Namespaces);
             }
             else

--- a/src/ScriptCs.Core/ScriptLibraryComposer.cs
+++ b/src/ScriptCs.Core/ScriptLibraryComposer.cs
@@ -139,7 +139,7 @@ namespace ScriptCs
                 var classDefinition = classBuilder.ToString();
                 _logger.TraceFormat("Class definition:{0}{0}{1}", Environment.NewLine, classDefinition);
                 builder.Append(classDefinition);
-                references.AddRange(result.References);
+                references.AddRange(result.AssemblyReferences);
                 namespaces.AddRange(result.Namespaces);
             }
         }

--- a/test/ScriptCs.Core.Tests/FileProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/FileProcessorTests.cs
@@ -197,9 +197,9 @@ namespace ScriptCs.Tests
                 var processor = GetFilePreProcessor();
                 var result = processor.ProcessFile("script1.csx");
 
-                result.References.Count.ShouldEqual(2);
-                result.References.ShouldContain("My.dll");
-                result.References.ShouldContain("My2.dll");
+                result.AssemblyReferences.Count.ShouldEqual(2);
+                result.AssemblyReferences.ShouldContain("My.dll");
+                result.AssemblyReferences.ShouldContain("My2.dll");
             }
 
             [Fact]
@@ -381,7 +381,7 @@ namespace ScriptCs.Tests
                 var processor = GetFilePreProcessor();
                 var result = processor.ProcessFile("script1.csx");
 
-                result.References.Count.ShouldEqual(2);
+                result.AssemblyReferences.Count.ShouldEqual(2);
             }
 
             [Fact]

--- a/test/ScriptCs.Core.Tests/ReferenceLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/ReferenceLineProcessorTests.cs
@@ -87,7 +87,7 @@ namespace ScriptCs.Tests
                 processor.ProcessLine(parser, context, Line, true);
 
                 // Assert
-                context.References.Count.ShouldEqual(1);
+                context.AssemblyReferences.Count.ShouldEqual(1);
             }
 
             [Theory, ScriptCsAutoData]
@@ -110,7 +110,7 @@ namespace ScriptCs.Tests
                 processor.ProcessLine(parser, context, line, true);
 
                 // Assert
-                context.References.Count(x => x == name).ShouldEqual(1);
+                context.AssemblyReferences.Count(x => x == name).ShouldEqual(1);
             }
 
             [Theory, ScriptCsAutoData]

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -257,7 +257,7 @@ namespace ScriptCs.Tests
                 repl.Setup(r => r.InjectScriptLibraries(It.IsAny<string>(), It.IsAny<FilePreProcessorResult>(), It.IsAny<IDictionary<string, object>>()))
                     .Callback((string p, FilePreProcessorResult r, IDictionary<string, object> s) =>
                     {
-                        r.References.Add("Foo.Bar");
+                        r.AssemblyReferences.Add("Foo.Bar");
                     });
 
                 scriptEngine.Setup(e => e.Execute(
@@ -383,7 +383,7 @@ namespace ScriptCs.Tests
                 mocks.FileSystem.Setup(i => i.GetFullPath(It.IsAny<string>())).Returns(@"c:/my.dll");
                 mocks.FileSystem.Setup(x => x.FileExists("c:/my.dll")).Returns(true);
                 mocks.FilePreProcessor.Setup(x => x.ProcessScript(It.IsAny<string>()))
-                    .Returns(new FilePreProcessorResult { References = new List<string> { "my.dll" } });
+                    .Returns(new FilePreProcessorResult { AssemblyReferences = new List<string> { "my.dll" } });
 
                 _repl = GetRepl(mocks);
                 _repl.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
@@ -400,7 +400,7 @@ namespace ScriptCs.Tests
                 mocks.FileSystem.Setup(i => i.CurrentDirectory).Returns("C:/");
                 mocks.FileSystem.Setup(i => i.GetFullPath(It.IsAny<string>())).Returns(@"C:/my.dll");
                 mocks.FilePreProcessor.Setup(x => x.ProcessScript(It.IsAny<string>()))
-                    .Returns(new FilePreProcessorResult { References = new List<string> { "my.dll" } });
+                    .Returns(new FilePreProcessorResult { AssemblyReferences = new List<string> { "my.dll" } });
 
                 _repl = GetRepl(mocks);
                 _repl.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
@@ -416,7 +416,7 @@ namespace ScriptCs.Tests
                 mocks.FileSystem.Setup(i => i.CurrentDirectory).Returns("C:/");
                 mocks.FileSystem.Setup(i => i.FileExists(It.IsAny<string>())).Returns(false);
                 mocks.FilePreProcessor.Setup(x => x.ProcessScript(It.IsAny<string>()))
-                    .Returns(new FilePreProcessorResult { References = new List<string> { "PresentationCore" } });
+                    .Returns(new FilePreProcessorResult { AssemblyReferences = new List<string> { "PresentationCore" } });
 
                 _repl = GetRepl(mocks);
                 _repl.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
@@ -433,7 +433,7 @@ namespace ScriptCs.Tests
                 mocks.FileSystem.Setup(i => i.GetFullPath(It.IsAny<string>())).Returns(@"C:/my.dll");
                 mocks.FileSystem.Setup(i => i.FileExists(It.IsAny<string>())).Returns(false);
                 mocks.FilePreProcessor.Setup(x => x.ProcessScript(It.IsAny<string>()))
-                    .Returns(new FilePreProcessorResult { References = new List<string> { "my.dll" } });
+                    .Returns(new FilePreProcessorResult { AssemblyReferences = new List<string> { "my.dll" } });
 
                 _repl = GetRepl(mocks);
                 _repl.Initialize(Enumerable.Empty<string>(), Enumerable.Empty<IScriptPack>());
@@ -450,7 +450,7 @@ namespace ScriptCs.Tests
                 mocks.FileSystem.Setup(i => i.GetFullPath(It.IsAny<string>())).Returns(@"C:/my.dll");
                 mocks.FileSystem.Setup(i => i.FileExists(It.IsAny<string>())).Returns(false);
                 mocks.FilePreProcessor.Setup(x => x.ProcessScript(It.IsAny<string>()))
-                    .Returns(new FilePreProcessorResult { References = new List<string> { "my.dll" } });
+                    .Returns(new FilePreProcessorResult { AssemblyReferences = new List<string> { "my.dll" } });
                 mocks.ScriptEngine.Setup(
                     i =>
                     i.Execute(It.IsAny<string>(), It.IsAny<string[]>(), It.IsAny<AssemblyReferences>(),

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -285,7 +285,7 @@ namespace ScriptCs.Tests
                 scriptExecutor.Setup(e => e.InjectScriptLibraries(It.IsAny<string>(), result, It.IsAny<IDictionary<string, object>>()))
                     .Callback((string p, FilePreProcessorResult r, IDictionary<string, object> s) =>
                     {
-                        r.References.Add("Foo.Bar");
+                        r.AssemblyReferences.Add("Foo.Bar");
                     });
 
                 scriptEngine.Setup(e => e.Execute(
@@ -593,9 +593,9 @@ namespace ScriptCs.Tests
             {
                 executor.Protected();
                 executor.Setup(e => e.LoadScriptLibraries(It.IsAny<string>())).Returns(_scriptLibrariesPreProcessorResult);
-                _scriptLibrariesPreProcessorResult.References.Add("ref1");
+                _scriptLibrariesPreProcessorResult.AssemblyReferences.Add("ref1");
                 executor.Object.InjectScriptLibraries("", _result, _state);
-                _result.References.ShouldContain("ref1");
+                _result.AssemblyReferences.ShouldContain("ref1");
             }
 
             [Theory, ScriptCsAutoData]

--- a/test/ScriptCs.Core.Tests/ScriptLibraryComposerTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptLibraryComposerTests.cs
@@ -141,7 +141,7 @@ namespace ScriptCs.Tests
                 packageContainer.Setup(c => c.FindPackage(It.IsAny<string>(), It.IsAny<IPackageReference>()))
                     .Returns(package.Object);
                 package.Setup(p => p.GetContentFiles()).Returns(new List<string> { "TestMain.csx" });
-                preProcessor.Setup(p => p.ProcessFile(It.IsAny<string>())).Returns(new FilePreProcessorResult { Code = "TestCode", References = new List<string> {"ref1", "ref2"}});
+                preProcessor.Setup(p => p.ProcessFile(It.IsAny<string>())).Returns(new FilePreProcessorResult { Code = "TestCode", AssemblyReferences = new List<string> {"ref1", "ref2"}});
                 var refs = new List<string>();
                 composer.ProcessPackage(@"c:\packages", reference.Object, new StringBuilder(), refs, new List<string>());
                 refs.ShouldContain("ref1");


### PR DESCRIPTION
For #1220 

# This is mostly a hack.

I've added support for paket directives in the REPL. This calls to the shim code which creates a paket.dependencies file, and calls to paket to install the packages and to create the load script.