### PR TITLE
Fix version info in mono builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,7 @@ sudo: false
 language: csharp
 mono:
   - 4.2.3
-install:
-  - nuget restore ./ScriptCs.sln
 
 script:
-  - mkdir -p artifacts/Release/bin
-  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
-  - xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
-  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
-  - cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
-  - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+  - ./build.sh
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 sudo: false
 language: csharp
-mono: 
+mono:
   - 4.2.3
 install:
   - nuget restore ./ScriptCs.sln
 
 script:
-  - mkdir artifacts --parents
-  - xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
+  - mkdir -p artifacts/Release/bin
+  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
+  - xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+  - xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
+  - cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
   - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,9 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:UpdateProjectVersions
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:m /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:RestoreCommonVersionInfo
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
+xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
 
 cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
 mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,9 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
-cp src/ScriptCs/bin/Release/* artifacts/Release/bin/
-mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:UpdateProjectVersions
+xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:m /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
+xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:m /target:RestoreCommonVersionInfo
 
+cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
+mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build.sh
+++ b/build.sh
@@ -5,13 +5,12 @@ set -x
 
 # install
 mozroots --import --sync --quiet
-mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:UpdateProjectVersions
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /v:n /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
-xbuild ./build/Build.proj /property:Configuration=Release /nologo /v:n /target:RestoreCommonVersionInfo
+xbuild ./build/Build.proj /nologo /v:M /t:Build "$@" /fl "/flp:LogFile=artifacts/msbuild.log;Verbosity=diagnostic;DetailedSummary"
 
-cp src/*/bin/Release/* artifacts/Release/bin/ 2>/dev/null
+# Not using Build.proj to copy artifacts or run tests due to bug: wildcard includes have incorrect and duplicate files
+# https://bugzilla.xamarin.com/show_bug.cgi?id=31628
+cp -r src/*/bin/Release artifacts/Release/bin/
 mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -4,7 +4,13 @@
   
   <Import Project="$(MSBuildThisFileDirectory)ScriptCs.Tasks.targets" />
   <Import Project="$(MSBuildThisFileDirectory)ScriptCs.Version.props" />
-  
+
+  <PropertyGroup>
+  	<IsMono>false</IsMono>
+  	<!-- Assuming !Windows = mono; not strictly true, but more correct determinations are more complicated, so this will do for now -->
+  	<IsMono Condition="'$(OS)' != 'Windows_NT'">true</IsMono>
+  </PropertyGroup>
+
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
 
@@ -14,6 +20,8 @@
     <PackageOutputPath>$(BaseArtifactsPath)$(Configuration)</PackageOutputPath>
     
     <NuGetExePath>$(Root).nuget\NuGet.exe</NuGetExePath>
+    <NuGetCommand Condition="!$(IsMono)">&quot;$(NuGetExePath)&quot;</NuGetCommand>
+    <NuGetCommand Condition="$(IsMono)">mono &quot;$(NuGetExePath)&quot;</NuGetCommand>
 
     <CommonVersionInfoPath>$([System.IO.Path]::Combine( $(Root), 'common\CommonVersionInfo.cs' ))</CommonVersionInfoPath>
   </PropertyGroup>
@@ -38,7 +46,7 @@
   </Target>
 
   <Target Name="Build" DependsOnTargets="RestorePackages; UpdateProjectVersions">
-    <MSBuild Projects="@(Solution)" Targets="Build">
+    <MSBuild Projects="@(Solution)" Targets="Build" Properties="Configuration=$(Configuration)">
       <Output TaskParameter="TargetOutputs" ItemName="ProjectAssemblies" />
     </MSBuild>
   </Target>
@@ -72,7 +80,7 @@
   </PropertyGroup>
 
   <Target Name="BuildChocolateyPackage">
-    <Exec Command="&quot;$(NuGetExePath)&quot; pack &quot;$(Root)src\ScriptCs\Properties\scriptcs.nuspec&quot; -BasePath &quot;$(Root)src\ScriptCs&quot; $(NuGetParameters)" />
+    <Exec Command="$(NuGetCommand) pack &quot;$(Root)src\ScriptCs\Properties\scriptcs.nuspec&quot; -BasePath &quot;$(Root)src\ScriptCs&quot; $(NuGetParameters)" />
   </Target>
 
   <Target Name="BuildNuGetPackages">
@@ -85,13 +93,13 @@
       <NuGetProjects Include="$(Root)src\ScriptCs\ScriptCs.csproj" />
     </ItemGroup>
     <Message Text="Building NuGet packages..." Importance="high" />
-    <Exec Command="&quot;$(NuGetExePath)&quot; pack &quot;%(NuGetProjects.Identity)&quot; $(NuGetParameters)" />
+    <Exec Command="$(NuGetExeCommand) pack &quot;%(NuGetProjects.Identity)&quot; $(NuGetParameters)" />
   </Target>
 
   <Target Name="RestorePackages">
     <Message Text="Restoring NuGet packages..." Importance="high" />
 
-    <Exec Command="&quot;$(NuGetExePath)&quot; restore -Verbosity detailed -NonInteractive"
+    <Exec Command="$(NuGetCommand) restore -Verbosity detailed -NonInteractive"
           WorkingDirectory="$(Root)" StandardOutputImportance="Low" />
   </Target>
 
@@ -108,7 +116,7 @@
     <RemoveDir Directories="$(ArtifactsPath)" Condition=" Exists('$(ArtifactsPath)') " ContinueOnError="true"/>
   </Target>
 
-  <Target Name="_CopyBinariesToArtifactsDirectory" AfterTargets="Build">
+  <Target Name="_CopyBinariesToArtifactsDirectory" AfterTargets="Build" Condition="!$(IsMono)">
     <ItemGroup>
       <FilesToCopy Include="$(Root)src\**\bin\$(Configuration)\*"/>
     </ItemGroup>

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -63,7 +63,8 @@
 
   <Target Name="RestoreCommonVersionInfo" AfterTargets="Build" Condition=" Exists('$(CommonVersionInfoPath).bak') ">
     <Delete Files="$(CommonVersionInfoPath)" Condition=" Exists('$(CommonVersionInfoPath)') " />
-    <Move SourceFiles="$(CommonVersionInfoPath).bak" DestinationFiles="$(CommonVersionInfoPath)" />
+    <Copy SourceFiles="$(CommonVersionInfoPath).bak" DestinationFiles="$(CommonVersionInfoPath)" />
+    <Delete Files="$(CommonVersionInfoPath).bak" Condition=" Exists('$(CommonVersionInfoPath).bak') " />
   </Target>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #1055 
Replaces #1080 

- Updates build.sh to use Build.proj, which allows the versioning tasks in Build.proj to work
- Small updates were necessary to make Build.proj work on mono
- As noted in build.sh, there is an [xbuild bug](https://bugzilla.xamarin.com/show_bug.cgi?id=31628) related to wildcard includes that made it impossible using Build.proj for copying artifacts and running acceptance tests