### PR TITLE
Updating to Microsoft.Web.Xdt version 2.1.1 for issue #1244

### DIFF
--- a/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
+++ b/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.Web.XmlTransform">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json">
       <HintPath>..\..\packages\Newtonsoft.Json.6.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/src/ScriptCs.Hosting/packages.config
+++ b/src/ScriptCs.Hosting/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net45" />
   <package id="Autofac.Mef" version="3.0.3" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.3" targetFramework="net45" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -85,9 +85,8 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+    <Reference Include="Microsoft.Web.XmlTransform">
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -3,7 +3,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -68,7 +68,7 @@
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
-      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.0\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
+      <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
     <Reference Include="Moq">
       <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>

--- a/test/ScriptCs.Hosting.Tests/packages.config
+++ b/test/ScriptCs.Hosting.Tests/packages.config
@@ -4,7 +4,7 @@
   <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
   <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
-  <package id="Microsoft.Web.Xdt" version="2.1.0" targetFramework="net45" />
+  <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />


### PR DESCRIPTION
Updating to version `2.1.1` of `Microsoft.Web.Xdt`. The old 2.1.0 is unlisted from NuGet.org. 
For more info, see #1244 

Fixes #1244 

This should do the trick. Cheers! 