### PR TITLE
Fix "using static" imports

### DIFF
--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -208,21 +208,23 @@ namespace ScriptCs
             }
 
             var scriptLibrariesPreProcessorResult = LoadScriptLibraries(workingDirectory);
-            var safeInsertIndex = result.Code.IndexOf("#line");
 
-            if (safeInsertIndex > -1)
+            // script libraries should be injected just before the #line directive
+            // if there is no #line directive, they can be injected at the beginning of code
+            if (result.Code == null) result.Code = string.Empty;
+            var safeInsertIndex = result.Code.IndexOf("#line");
+            if (safeInsertIndex < 0) safeInsertIndex = 0;
+
+            if (scriptLibrariesPreProcessorResult != null)
             {
-                if (scriptLibrariesPreProcessorResult != null)
-                {
-                    result.Code = result.Code.Insert(safeInsertIndex, scriptLibrariesPreProcessorResult.Code + Environment.NewLine
-                                  + "Env.Initialize();" + Environment.NewLine);
-                    result.References.AddRange(scriptLibrariesPreProcessorResult.References);
-                    result.Namespaces.AddRange(scriptLibrariesPreProcessorResult.Namespaces);
-                }
-                else
-                {
-                    result.Code = result.Code.Insert(safeInsertIndex, "Env.Initialize();" + Environment.NewLine);
-                }
+                result.Code = result.Code.Insert(safeInsertIndex, scriptLibrariesPreProcessorResult.Code + Environment.NewLine
+                              + "Env.Initialize();" + Environment.NewLine);
+                result.References.AddRange(scriptLibrariesPreProcessorResult.References);
+                result.Namespaces.AddRange(scriptLibrariesPreProcessorResult.Namespaces);
+            }
+            else
+            {
+                result.Code = result.Code.Insert(safeInsertIndex, "Env.Initialize();" + Environment.NewLine);
             }
 
             state.Add(ScriptLibrariesInjected, null);

--- a/src/ScriptCs.Core/ScriptExecutor.cs
+++ b/src/ScriptCs.Core/ScriptExecutor.cs
@@ -208,21 +208,24 @@ namespace ScriptCs
             }
 
             var scriptLibrariesPreProcessorResult = LoadScriptLibraries(workingDirectory);
+            var safeInsertIndex = result.Code.IndexOf("#line");
 
-            if (scriptLibrariesPreProcessorResult != null)
+            if (safeInsertIndex > -1)
             {
-                result.Code = scriptLibrariesPreProcessorResult.Code + Environment.NewLine
-                              + "Env.Initialize();" + Environment.NewLine
-                              + result.Code;
-                result.References.AddRange(scriptLibrariesPreProcessorResult.References);
-                result.Namespaces.AddRange(scriptLibrariesPreProcessorResult.Namespaces);
+                if (scriptLibrariesPreProcessorResult != null)
+                {
+                    result.Code = result.Code.Insert(safeInsertIndex, scriptLibrariesPreProcessorResult.Code + Environment.NewLine
+                                  + "Env.Initialize();" + Environment.NewLine);
+                    result.References.AddRange(scriptLibrariesPreProcessorResult.References);
+                    result.Namespaces.AddRange(scriptLibrariesPreProcessorResult.Namespaces);
+                }
+                else
+                {
+                    result.Code = result.Code.Insert(safeInsertIndex, "Env.Initialize();" + Environment.NewLine);
+                }
             }
-            else
-            {
-                result.Code = "Env.Initialize();" + Environment.NewLine + result.Code;
-            }
+
             state.Add(ScriptLibrariesInjected, null);
-
         }
 
         protected internal virtual FilePreProcessorResult LoadScriptLibraries(string workingDirectory)

--- a/src/ScriptCs.Core/UsingLineProcessor.cs
+++ b/src/ScriptCs.Core/UsingLineProcessor.cs
@@ -19,6 +19,12 @@ namespace ScriptCs
                 return false;
             }
 
+            // for using static, we will not extract the import into the context, but rather let it be treated as code
+            if (line.Contains(" static "))
+            {
+                return false;
+            }
+
             var @namespace = GetNamespace(line);
             if (!context.Namespaces.Contains(@namespace))
             {
@@ -30,7 +36,7 @@ namespace ScriptCs
 
         private static bool IsUsingLine(string line)
         {
-            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";") && !line.Contains("=") && !line.Contains("static");
+            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";") && !line.Contains("=");
         }
 
         private static string GetNamespace(string line)

--- a/src/ScriptCs.Core/UsingLineProcessor.cs
+++ b/src/ScriptCs.Core/UsingLineProcessor.cs
@@ -30,7 +30,7 @@ namespace ScriptCs
 
         private static bool IsUsingLine(string line)
         {
-            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";") && !line.Contains("=");
+            return line.Trim(' ').StartsWith(UsingString) && !line.Contains("{") && line.Contains(";") && !line.Contains("=") && !line.Contains("static");
         }
 
         private static string GetNamespace(string line)

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props" Condition="Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -16,6 +17,8 @@
     <NoWarn>1701</NoWarn>
     <LangVersion>5</LangVersion>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -127,4 +130,11 @@
   </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\xunit.runner.visualstudio.2.2.0\build\net20\xunit.runner.visualstudio.props'))" />
+  </Target>
 </Project>

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -130,7 +130,6 @@
   </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-</Project>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>

--- a/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
@@ -14,7 +14,7 @@ namespace ScriptCs.Tests
             public void ShouldReturnTrueOnUsingLine(IFileParser parser, UsingLineProcessor processor)
             {
                 // Arrange
-                const string UsingLine = @"using ""System.Data"";";
+                const string UsingLine = "using System.Data;";
 
                 // Act
                 var result = processor.ProcessLine(parser, new FileParserContext(), UsingLine, true);
@@ -40,7 +40,21 @@ namespace ScriptCs.Tests
             public void ShouldIgnoreAliases(IFileParser parser, UsingLineProcessor processor)
             {
                 // Arrange
-                const string UsingLine = @"using Path = ""System.IO.Path"";";
+                const string UsingLine = "using Path = System.IO.Path";
+
+                // Act
+                var result = processor.ProcessLine(parser, new FileParserContext(), UsingLine, true);
+
+                // Assert
+                result.ShouldBeFalse();
+            }
+
+            [Theory, ScriptCsAutoData]
+            public void ShouldIgnoreUsingStatic(IFileParser parser, UsingLineProcessor processor)
+            {
+                // Arrange
+                const string UsingLine = "using static System.Console;";
+                var context = new FileParserContext();
 
                 // Act
                 var result = processor.ProcessLine(parser, new FileParserContext(), UsingLine, true);
@@ -53,7 +67,7 @@ namespace ScriptCs.Tests
             public void ShouldAddNamespaceToContext(IFileParser parser, UsingLineProcessor processor)
             {
                 // Arrange
-                const string UsingLine = @"using ""System.Data"";";
+                const string UsingLine = "using System.Data;";
                 var context = new FileParserContext();
 
                 // Act

--- a/test/ScriptCs.Core.Tests/app.config
+++ b/test/ScriptCs.Core.Tests/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705"/>
+        <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112"/>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -10,4 +10,5 @@
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit" version="1.9.2" targetFramework="net45" />
   <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
@@ -57,7 +57,7 @@ namespace ScriptCs.Tests.Acceptance
 
             "Given a script which defined a static import"
                 .f(() => directory = ScenarioDirectory.Create(scenario)
-                    .WriteLine("foo.csx", @"using static System.Console; WriteLine(""Hello world!"")"));
+                    .WriteLine("foo.csx", "using static System.Console;" + Environment.NewLine + @"WriteLine(""Hello world!"");"));
 
             "When I execute the script"
                 .f(() => output = ScriptCsExe.Run("foo.csx", directory));

--- a/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
@@ -51,6 +51,22 @@ namespace ScriptCs.Tests.Acceptance
         }
 
         [Scenario]
+        public static void ScriptCanWorkWithUsingStatic(ScenarioDirectory directory, string output)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which defined a static import"
+                .f(() => directory = ScenarioDirectory.Create(scenario)
+                    .WriteLine("foo.csx", @"using static System.Console; WriteLine(""Hello world!"")"));
+
+            "When I execute the script"
+                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+
+            "Then I see 'Hello world!'"
+                .f(() => output.ShouldContain("Hello world!"));
+        }
+
+        [Scenario]
         public static void ScriptCanAccessEnv(ScenarioDirectory directory, string output )
         {
             var scenario = MethodBase.GetCurrentMethod().GetFullName();


### PR DESCRIPTION
Fixes #1184 

It's not the most elegant solution in the world, but given our current architecture it's OK.
The statements are still recognized as `usings` by our code (this ensures we don't break debugging), but we don't lift them out of the source code anymore. 

Long term we should probably just reference `Microsoft.CodeAnalysis.CSharp` from the core package and use Roslyn for all these parsings.
I needed to tweak some script library injection code because it went into the wrong place.