### PR TITLE
Don't crash REPL on unserializable types

### DIFF
--- a/src/ScriptCs.Hosting/ObjectSerializer.cs
+++ b/src/ScriptCs.Hosting/ObjectSerializer.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using ScriptCs.Contracts;

--- a/test/ScriptCs.Hosting.Tests/ObjectSerializerTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ObjectSerializerTests.cs
@@ -80,7 +80,8 @@ namespace ScriptCs.Hosting.Tests
                 var obj = new Process();
 
                 string result = null;
-                Assert.DoesNotThrow(() => result = _serializer.Serialize(obj));
+                var exception = Record.Exception(() => result = _serializer.Serialize(obj));
+                exception.ShouldBeNull();
                 Assert.Equal("Couldn't serialize a returned instance of System.Diagnostics.Process", result);
             }
 

--- a/test/ScriptCs.Hosting.Tests/ObjectSerializerTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ObjectSerializerTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Should;
 using Xunit;
+using System.Diagnostics;
 
 namespace ScriptCs.Hosting.Tests
 {
@@ -71,6 +72,16 @@ namespace ScriptCs.Hosting.Tests
 
                 // assert
                 exception.ShouldBeNull();
+            }
+
+            [Fact]
+            public void ShouldNotShowExceptionForUnserializableTypes()
+            {
+                var obj = new Process();
+
+                string result = null;
+                Assert.DoesNotThrow(() => result = _serializer.Serialize(obj));
+                Assert.Equal("Couldn't serialize a returned instance of System.Diagnostics.Process", result);
             }
 
             [Fact]


### PR DESCRIPTION
Fixes #1121 

Instead of showing a nasty JSON serialization exception and breaking the REPL, we just show something like this:

```
> using System.Diagnostics;
> Process.Start(@"C:\Windows\System32\notepad.exe")
Couldn't serialize a returned instance of System.Diagnostics.Process
> 
```