### PR TITLE
print a better exception when script pack is not found

### DIFF
--- a/src/ScriptCs.Core/Exceptions/ScriptPackException.cs
+++ b/src/ScriptCs.Core/Exceptions/ScriptPackException.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace ScriptCs.Exceptions
+{
+    [Serializable]
+    public class ScriptPackException : Exception
+    {
+        public ScriptPackException(string message)
+            : base(message)
+        {
+        }
+
+        protected ScriptPackException(SerializationInfo info, StreamingContext context)
+            : base(info, context)
+        {
+        }
+    }
+}

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -49,6 +49,7 @@
     <Compile Include="AssemblyInfo.cs" />
     <Compile Include="AssemblyResolver.cs" />
     <Compile Include="AssemblyUtility.cs" />
+    <Compile Include="Exceptions\ScriptPackException.cs" />
     <Compile Include="Extensions\EnumerableExtensions.cs" />
     <Compile Include="Extensions\MethodInfoExtensions.cs" />
     <Compile Include="FileSystemMigrator.cs" />

--- a/src/ScriptCs.Core/ScriptPackManager.cs
+++ b/src/ScriptCs.Core/ScriptPackManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using ScriptCs.Contracts;
+using ScriptCs.Exceptions;
 
 namespace ScriptCs
 {
@@ -20,7 +21,13 @@ namespace ScriptCs
 
         public TContext Get<TContext>() where TContext : IScriptPackContext
         {
-            return (TContext)_contexts[typeof(TContext)];
+            var key = typeof(TContext);
+            if (!_contexts.ContainsKey(key))
+            {
+                throw new ScriptPackException(string.Format("Tried to resolve a script pack '{0}', but such script pack is not available in the current execution context.", key));
+            }
+
+            return (TContext)_contexts[key];
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -102,6 +102,12 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ScriptCs.Core\ScriptCs.Core.csproj">
+      <Project>{E590E710-E159-48E6-A3E6-1A83D3FE732C}</Project>
+      <Name>ScriptCs.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
@@ -4,6 +4,9 @@
     using ScriptCs.Tests.Acceptance.Support;
     using Should;
     using Xbehave;
+    using System;
+    using Should.Core.Assertions;
+    using ScriptCs.Exceptions;
 
     public static class ScriptPacks
     {
@@ -24,6 +27,30 @@
 
             "Then I see 6912"
                 .f(() => output.ShouldContain("6912"));
+        }
+
+        [Scenario]
+        public static void UsingAnUnavailableScriptPack(ScenarioDirectory directory, string output, Exception exception)
+        {
+            var scenario = MethodBase.GetCurrentMethod().GetFullName();
+
+            "Given a script which uses a non-existing script pack 'Foo'"
+                .f(() => directory = ScenarioDirectory.Create(scenario)
+                    .WriteLine("foo.csx", @"var fooContext = Require<Foo>();
+                        class Foo : ScriptCs.Contracts.IScriptPackContext{}
+                        Console.WriteLine(""hi"");"));
+
+            "When I execute the script"
+                .f(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
+
+            "Then scriptcs fails"
+                .f(() => exception.ShouldBeType<ScriptCsException>());
+
+            "With a script pack exception"
+                .f(() =>
+                {
+                    exception.Message.ShouldContain("Tried to resolve a script pack 'Submission#0+Foo', but such script pack is not available in the current execution context.");
+                });
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
@@ -16,17 +16,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Adder to print the sum of 1234 and 5678"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(Require<Adder>().Add(1234, 5678));"));
 
             "And ScriptCs.Adder is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
 
             "When execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then I see 6912"
-                .f(() => output.ShouldContain("6912"));
+                .x(() => output.ShouldContain("6912"));
         }
 
         [Scenario]
@@ -35,19 +35,19 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses a non-existing script pack 'Foo'"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"var fooContext = Require<Foo>();
                         class Foo : ScriptCs.Contracts.IScriptPackContext{}
                         Console.WriteLine(""hi"");"));
 
             "When I execute the script"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
 
             "Then scriptcs fails"
-                .f(() => exception.ShouldBeType<ScriptCsException>());
+                .x(() => exception.ShouldBeType<ScriptCsException>());
 
             "With a script pack exception"
-                .f(() =>
+                .x(() =>
                 {
                     exception.Message.ShouldContain("Tried to resolve a script pack 'Submission#0+Foo', but such script pack is not available in the current execution context.");
                 });


### PR DESCRIPTION
Fixes #1170 

Instead of:

```
ERROR: Script execution failed. [System.Collections.Generic.KeyNotFoundException] The given key was not present in the dictionary.
```

We now say:

```
ERROR: Script execution failed. [ScriptPackException] Tried to resolve a script pack 'Submission#0+Foo', 
but such script pack is not available in the current execution context.
```