### PR TITLE
Updated to latest xUnit (+ other testing libraries)

### DIFF
--- a/.nuget/packages.config
+++ b/.nuget/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="xunit.runners" version="1.9.2" />
+  <package id="xunit.runner.console" version="2.2.0" />
+  <package id="xunit.runner.msbuild" version="2.2.0" />
 </packages>

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
     fi
 
 install:
+  - mono .nuget/NuGet.exe restore ./.nuget/packages.config -PackagesDirectory ./packages
   - mono .nuget/NuGet.exe restore ./ScriptCs.sln
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 script:
   - mkdir artifacts --parents
   - msbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
-  - mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+  - mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 script:
   - mkdir artifacts --parents
   - msbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
-  - mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+  - mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll
 
 addons:
   apt:

--- a/build.sh
+++ b/build.sh
@@ -11,5 +11,5 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 mkdir -p artifacts/Release/bin
 xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
 cp src/ScriptCs/bin/Release/* artifacts/Release/bin/
-mono ./packages/xunit.runners.1.9.2/tools/xunit.console.clr4.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+mono ./packages/xunit.runner.console.1.9.2/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
 

--- a/build.sh
+++ b/build.sh
@@ -12,5 +12,5 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 mkdir -p artifacts/Release/bin
 msbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
 cp src/ScriptCs/bin/Release/* artifacts/Release/bin/
-mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll
 

--- a/build.sh
+++ b/build.sh
@@ -5,6 +5,7 @@ set -x
 
 # install
 mozroots --import --sync --quiet
+mono ./.nuget/NuGet.exe restore ./.nuget/packages.config -PackagesDirectory ./packages
 mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script

--- a/build.sh
+++ b/build.sh
@@ -9,7 +9,7 @@ mono ./.nuget/NuGet.exe restore ./ScriptCs.sln
 
 # script
 mkdir -p artifacts/Release/bin
-xbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
+msbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
 cp src/ScriptCs/bin/Release/* artifacts/Release/bin/
-mono ./packages/xunit.runner.console.1.9.2/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
+mono ./packages/xunit.runner.console.2.2.0/tools/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/ScriptCs.Tests.Acceptance.dll /xml artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.xml /html artifacts/ScriptCs.Tests.Acceptance.dll.TestResult.html
 

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="FullBuild" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask AssemblyFile="..\packages\xunit.runners.1.9.2\tools\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
+  <UsingTask AssemblyFile="..\packages\xunit.runner.msbuild.2.2.0\build\net452\xunit.runner.msbuild.dll" TaskName="Xunit.Runner.MSBuild.xunit" />
   
   <Import Project="$(MSBuildThisFileDirectory)ScriptCs.Tasks.targets" />
   <Import Project="$(MSBuildThisFileDirectory)ScriptCs.Version.props" />

--- a/test/ScriptCs.Core.Tests/AppDomainAssemblyResolverTests.cs
+++ b/test/ScriptCs.Core.Tests/AppDomainAssemblyResolverTests.cs
@@ -4,11 +4,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using Should;
 using Xunit;
 using Xunit.Extensions;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/AssemblyResolverTests.cs
+++ b/test/ScriptCs.Core.Tests/AssemblyResolverTests.cs
@@ -1,10 +1,10 @@
 ﻿using System.IO;
 using System.Linq;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/FileProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/FileProcessorTests.cs
@@ -307,7 +307,8 @@ namespace ScriptCs.Tests
                 _fileSystem.Setup(x => x.ReadFileLines("A.csx")).Returns(a.ToArray());
                 _fileSystem.Setup(x => x.ReadFileLines("B.csx")).Returns(b.ToArray());
 
-                Assert.DoesNotThrow(() => GetFilePreProcessor().ProcessFile("A.csx"));
+                var ex = Record.Exception(() => GetFilePreProcessor().ProcessFile("A.csx"));
+                Assert.Null(ex);
             }
 
             [Fact]
@@ -660,9 +661,8 @@ namespace ScriptCs.Tests
                         "Console.WriteLine(\"Success\");"
                     };
 
-                Assert.DoesNotThrow(
-                    ()=> filePreprocessor.ParseScript(lines, new FileParserContext())
-                );
+                var ex = Record.Exception(() => filePreprocessor.ParseScript(lines, new FileParserContext()));
+                Assert.Null(ex);
             }
 
             [Fact]

--- a/test/ScriptCs.Core.Tests/FileSystemMigratorTests.cs
+++ b/test/ScriptCs.Core.Tests/FileSystemMigratorTests.cs
@@ -1,7 +1,7 @@
 ﻿using Moq;
-using Ploeh.AutoFixture.Xunit;
+using Ploeh.AutoFixture.Xunit2;
 using ScriptCs.Contracts;
-using Xunit.Extensions;
+using Xunit;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/LoadLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/LoadLineProcessorTests.cs
@@ -1,16 +1,11 @@
 ﻿using System;
-
 using Moq;
-
-using Ploeh.AutoFixture.Xunit;
-
 using ScriptCs.Contracts;
-
 using Should;
-
-using Xunit.Extensions;
 using Should.Core.Assertions;
 using ScriptCs.Contracts.Exceptions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {
@@ -69,7 +64,7 @@ namespace ScriptCs.Tests
                 fileSystem.Setup(x => x.GetFullPath(RelativePath)).Returns(FullPath);
 
                 // Act / Assert
-                Assert.Throws(typeof(InvalidDirectiveUseException), () => processor.ProcessLine(parser.Object, context, Line, false));
+                Xunit.Assert.Throws(typeof(InvalidDirectiveUseException), () => processor.ProcessLine(parser.Object, context, Line, false));
             }
 
             [Theory, ScriptCsAutoData]

--- a/test/ScriptCs.Core.Tests/PackageReferenceTests.cs
+++ b/test/ScriptCs.Core.Tests/PackageReferenceTests.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.Versioning;
 using Should;
-using Xunit.Extensions;
+using Xunit;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/ReferenceLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/ReferenceLineProcessorTests.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using Should;
-using Xunit.Extensions;
 using System.Linq;
 using Should.Core.Assertions;
 using ScriptCs.Contracts.Exceptions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {
@@ -63,9 +63,9 @@ namespace ScriptCs.Tests
                 const string FullPath = "C:\\script.csx";
 
                 fileSystem.Setup(x => x.GetFullPath(RelativePath)).Returns(FullPath);
-                
+
                 // Act / Assert
-                Assert.Throws(typeof(InvalidDirectiveUseException), () => processor.ProcessLine(parser, context, Line, false));
+                Xunit.Assert.Throws(typeof(InvalidDirectiveUseException), () => processor.ProcessLine(parser, context, Line, false));
             }
 
             [Theory, ScriptCsAutoData]

--- a/test/ScriptCs.Core.Tests/ReplTests.cs
+++ b/test/ScriptCs.Core.Tests/ReplTests.cs
@@ -4,11 +4,10 @@ using System.IO;
 using System.Linq;
 using Moq;
 using Moq.Protected;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using Should;
 using Xunit;
-using Xunit.Extensions;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
+++ b/test/ScriptCs.Core.Tests/ScriptCs.Core.Tests.csproj
@@ -88,34 +88,44 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture">
-      <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq">
-      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.18.8\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.50.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit">
-      <HintPath>..\..\packages\AutoFixture.Xunit.3.18.8\lib\net40\Ploeh.AutoFixture.Xunit.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.3.50.3\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptExecutorTests.cs
@@ -2,14 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Security.Policy;
 using Moq;
 using Moq.Protected;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using Should;
 using Xunit;
-using Xunit.Extensions;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/ScriptLibraryComposerTests.cs
+++ b/test/ScriptCs.Core.Tests/ScriptLibraryComposerTests.cs
@@ -5,9 +5,9 @@ using System.Text;
 using ScriptCs.Contracts;
 using Moq;
 using Moq.Protected;
-using Ploeh.AutoFixture.Xunit;
-using Xunit.Extensions;
 using Should;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/ShebangLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/ShebangLineProcessorTests.cs
@@ -1,6 +1,7 @@
 using Should;
 using Xunit.Extensions;
 using ScriptCs.Contracts;
+using Xunit;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
+++ b/test/ScriptCs.Core.Tests/UsingLineProcessorTests.cs
@@ -1,8 +1,6 @@
 ﻿using ScriptCs.Contracts;
-
 using Should;
-
-using Xunit.Extensions;
+using Xunit;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Core.Tests/app.config
+++ b/test/ScriptCs.Core.Tests/app.config
@@ -8,7 +8,15 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
+        <bindingRedirect oldVersion="0.0.0.0-4.7.99.0" newVersion="4.7.99.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.50.0.0" newVersion="3.50.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ScriptCs.Core.Tests/packages.config
+++ b/test/ScriptCs.Core.Tests/packages.config
@@ -1,14 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="AutoFixture" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="3.50.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="Moq" version="4.7.99" targetFramework="net461" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
   <package id="xunit.runner.visualstudio" version="2.2.0" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpReplEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpReplEngineTests.cs
@@ -2,11 +2,11 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using ScriptCs.Engine.Roslyn;
 using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
+++ b/test/ScriptCs.Engine.Roslyn.Tests/CSharpScriptEngineTests.cs
@@ -3,12 +3,11 @@ using System.Reflection;
 using Microsoft.CodeAnalysis.CSharp.Scripting;
 using Microsoft.CodeAnalysis.Scripting;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using ScriptCs.Engine.Roslyn;
 using Should;
 using Xunit;
-using Xunit.Extensions;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {
@@ -24,6 +23,7 @@ namespace ScriptCs.Tests
             {
                 _printers =  new Printers(_serializer);
             }
+
             [Theory, ScriptCsAutoData]
             public void ShouldCreateScriptHostWithContexts(
                 [Frozen] Mock<IScriptHostFactory> scriptHostFactory,

--- a/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
+++ b/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
@@ -58,6 +58,9 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
@@ -70,17 +73,17 @@
     <Reference Include="Microsoft.CodeAnalysis.Scripting, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Scripting.Common.2.3.1\lib\netstandard1.3\Microsoft.CodeAnalysis.Scripting.dll</HintPath>
     </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture">
-      <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq">
-      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.18.8\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.50.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit">
-      <HintPath>..\..\packages\AutoFixture.Xunit.3.18.8\lib\net40\Ploeh.AutoFixture.Xunit.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.3.50.3\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
@@ -115,11 +118,17 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Engine.Roslyn.Tests/app.config
+++ b/test/ScriptCs.Engine.Roslyn.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
+        <bindingRedirect oldVersion="0.0.0.0-4.7.99.0" newVersion="4.7.99.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
@@ -61,6 +61,14 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Ploeh.AutoFixture" publicKeyToken="b24654c590009d4f" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.50.0.0" newVersion="3.50.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ScriptCs.Engine.Roslyn.Tests/packages.config
+++ b/test/ScriptCs.Engine.Roslyn.Tests/packages.config
@@ -1,14 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="AutoFixture" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="3.50.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Analyzers" version="1.1.0" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Common" version="2.3.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp" version="2.3.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.CSharp.Scripting" version="2.3.1" targetFramework="net461" />
   <package id="Microsoft.CodeAnalysis.Scripting.Common" version="2.3.1" targetFramework="net461" />
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="Moq" version="4.7.99" targetFramework="net461" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
   <package id="System.AppContext" version="4.3.0" targetFramework="net461" />
@@ -53,6 +54,10 @@
   <package id="System.Xml.XmlDocument" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XPath" version="4.3.0" targetFramework="net461" />
   <package id="System.Xml.XPath.XDocument" version="4.3.0" targetFramework="net461" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
 </packages>

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -70,6 +70,13 @@
     <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
@@ -94,6 +101,13 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -67,35 +67,44 @@
     <Reference Include="Autofac">
       <HintPath>..\..\packages\Autofac.3.3.1\lib\net40\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
     </Reference>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture">
-      <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq">
-      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.18.8\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.50.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit">
-      <HintPath>..\..\packages\AutoFixture.Xunit.3.18.8\lib\net40\Ploeh.AutoFixture.Xunit.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.3.50.3\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Hosting.Tests/ScriptServicesBuilderTests.cs
+++ b/test/ScriptCs.Hosting.Tests/ScriptServicesBuilderTests.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Contracts;
 using ScriptCs.Tests;
 using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Hosting.Tests
 {

--- a/test/ScriptCs.Hosting.Tests/app.config
+++ b/test/ScriptCs.Hosting.Tests/app.config
@@ -14,6 +14,10 @@
         <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0"  newVersion="15.0.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 <startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/ScriptCs.Hosting.Tests/app.config
+++ b/test/ScriptCs.Hosting.Tests/app.config
@@ -1,15 +1,19 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112"/>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.7.99.0" newVersion="4.7.99.0" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705"/>
+        <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.9.2.1705" newVersion="1.9.2.1705" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" /></startup></configuration>

--- a/test/ScriptCs.Hosting.Tests/packages.config
+++ b/test/ScriptCs.Hosting.Tests/packages.config
@@ -5,11 +5,13 @@
   <package id="AutoFixture.AutoMoq" version="3.50.3" targetFramework="net461" />
   <package id="AutoFixture.Xunit2" version="3.50.3" targetFramework="net461" />
   <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
+  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
   <package id="Moq" version="4.7.99" targetFramework="net461" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net461" />

--- a/test/ScriptCs.Hosting.Tests/packages.config
+++ b/test/ScriptCs.Hosting.Tests/packages.config
@@ -1,14 +1,19 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.3.1" targetFramework="net45" />
-  <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
+  <package id="AutoFixture" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="3.50.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net45" />
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="Moq" version="4.7.99" targetFramework="net461" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net45" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
 </packages>

--- a/test/ScriptCs.Tests.Acceptance/CommandLine.cs
+++ b/test/ScriptCs.Tests.Acceptance/CommandLine.cs
@@ -15,7 +15,7 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "When I execute scriptcs with an unknown option"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run(
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run(
                     new[]
                     {
                         "-unknownoption"
@@ -23,10 +23,10 @@ namespace ScriptCs.Tests.Acceptance
                     ScenarioDirectory.Create(scenario))));
 
             "Then scriptcs errors"
-                .f(() => exception.ShouldBeType<ScriptCsException>());
+                .x(() => exception.ShouldBeType<ScriptCsException>());
 
             "And I see an error message regarding the unknown option"
-                .f(() =>
+                .x(() =>
                 {
                     Console.WriteLine(exception);
                     exception.Message.ShouldContain("unknownoption");

--- a/test/ScriptCs.Tests.Acceptance/Configuration.cs
+++ b/test/ScriptCs.Tests.Acceptance/Configuration.cs
@@ -13,17 +13,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a hello world script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(""Hello world!"");"));
 
             "And a local config file specfying the log level as debug"
-                .f(() => directory.WriteLine("scriptcs.opts", @"{ logLevel: ""debug"" }"));
+                .x(() => directory.WriteLine("scriptcs.opts", @"{ logLevel: ""debug"" }"));
 
             "When I execute the script without the log level option"
-                .f(() => output = ScriptCsExe.Run("foo.csx", false, directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", false, directory));
 
             "Then I see debug messages"
-                .f(() => output.ShouldContain("DEBUG:"));
+                .x(() => output.ShouldContain("DEBUG:"));
         }
 
         [Scenario]
@@ -32,21 +32,21 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a hello world script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(""Hello world!"");"));
 
             "And a local config file specfying to run as debug"
-                .f(() => directory.WriteLine("custom.opts", @"{ logLevel: ""debug"" }"));
+                .x(() => directory.WriteLine("custom.opts", @"{ logLevel: ""debug"" }"));
 
             "When I execute the script without the log level option but specifying the custom config"
-                .f(() =>
+                .x(() =>
                 {
                     var args = new[] { "-config", "custom.opts", };
                     output = ScriptCsExe.Run("foo.csx", false, args, directory);
                 });
 
             "Then I see debug messages"
-                .f(() => output.ShouldContain("DEBUG:"));
+                .x(() => output.ShouldContain("DEBUG:"));
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/DirectoryCleaning.cs
+++ b/test/ScriptCs.Tests.Acceptance/DirectoryCleaning.cs
@@ -14,22 +14,22 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a directory"
-                .f(() => directory = ScenarioDirectory.Create(scenario));
+                .x(() => directory = ScenarioDirectory.Create(scenario));
 
             "And the directory has an installed package"
-                .f(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
 
             "And the directory has an assembly cache"
-                .f(() => directory.WriteLine(Path.Combine(directory.Map(ScriptCsExe.DllCacheFolder), "foo.txt"), null));
+                .x(() => directory.WriteLine(Path.Combine(directory.Map(ScriptCsExe.DllCacheFolder), "foo.txt"), null));
 
             "When I clean the directory"
-                .f(() => ScriptCsExe.Clean(directory));
+                .x(() => ScriptCsExe.Clean(directory));
 
             "Then the packages folder is removed"
-                .f(() => Directory.Exists(directory.Map(ScriptCsExe.PackagesFolder)).ShouldBeFalse());
+                .x(() => Directory.Exists(directory.Map(ScriptCsExe.PackagesFolder)).ShouldBeFalse());
 
             "And the assembly cache folder is removed"
-                .f(() => Directory.Exists(directory.Map(ScriptCsExe.DllCacheFolder)).ShouldBeFalse());
+                .x(() => Directory.Exists(directory.Map(ScriptCsExe.DllCacheFolder)).ShouldBeFalse());
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/ImplicitInstallation.cs
+++ b/test/ScriptCs.Tests.Acceptance/ImplicitInstallation.cs
@@ -14,11 +14,11 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Adder to print the sum of 1234 and 5678"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(Require<Adder>().Add(1234, 5678));"));
 
             "And a legacy packages file declaring the ScriptCs.Adder dependency"
-                .f(() =>
+                .x(() =>
                 {
                     var nugetConfig =
 @"<?xml version=""1.0"" encoding=""utf-8""?>
@@ -44,10 +44,10 @@
                 });
 
             "When execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then I see 6912"
-                .f(() => output.ShouldContain("6912"));
+                .x(() => output.ShouldContain("6912"));
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/LooseScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/LooseScriptExecution.cs
@@ -17,7 +17,7 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a hello world script"
-                .f(() =>
+                .x(() =>
                 {
                     directory = ScenarioDirectory.Create(scenario);
                     if (Environment.OSVersion.Platform == PlatformID.Win32NT)
@@ -32,10 +32,10 @@
                 });
 
             "When I execute the script with debug set to {0}"
-                .f(() => output = ScriptCsExe.Run(args, debug, directory));
+                .x(() => output = ScriptCsExe.Run(args, debug, directory));
 
             "Then I see 'Hello World!'"
-                .f(() => output.ShouldContain("Hello World!"));
+                .x(() => output.ShouldContain("Hello World!"));
         }
 
         [Scenario]
@@ -46,7 +46,7 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which throws an exception"
-                .f(() =>
+                .x(() =>
                 {
                     directory = ScenarioDirectory.Create(scenario);
                     if (Environment.OSVersion.Platform == PlatformID.Win32NT)
@@ -62,13 +62,13 @@
                 });
 
             "When I execute the script with debug set to {0}"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run(args, debug, directory)));
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run(args, debug, directory)));
 
             "Then scriptcs fails"
-                .f(() => exception.ShouldBeType<ScriptCsException>());
+                .x(() => exception.ShouldBeType<ScriptCsException>());
 
             "And I see the exception message"
-                .f(() =>
+                .x(() =>
                 {
                     exception.Message.ShouldContain("BOOM!");
                 });
@@ -80,17 +80,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which access Env"
-                .f(() =>
+                .x(() =>
                 {
                     directory = ScenarioDirectory.Create(scenario);
                     script = "Console.WriteLine(Env)";
                     args = new[] {"-e", script};
                 });
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run(args, directory));
+                .x(() => output = ScriptCsExe.Run(args, directory));
 
             "Then the Env object is displayed"
-                .f(() => output.ShouldContain("ScriptCs.ScriptEnvironment"));
+                .x(() => output.ShouldContain("ScriptCs.ScriptEnvironment"));
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/Migration.cs
+++ b/test/ScriptCs.Tests.Acceptance/Migration.cs
@@ -14,7 +14,7 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script directory with a full population of legacy artifacts including a hello world script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                 .WriteLine("bin/foo.txt", null)
                 .WriteLine(".cache/foo.txt", null)
                 .WriteLine("packages/foo.txt", null)
@@ -23,10 +23,10 @@
                 .WriteLine("hello.csx", @"Console.WriteLine(""Hello, World!"");"));
 
             "When I execute the script"
-                .f(() => ScriptCsExe.Run("hello.csx", directory));
+                .x(() => ScriptCsExe.Run("hello.csx", directory));
 
             "Then the artifacts are migrated"
-                .f(() =>
+                .x(() =>
                 {
                     File.Exists(directory.Map("bin/foo.txt")).ShouldBeTrue("bin/ is unchanged");
                     File.Exists(directory.Map(".cache/foo.txt")).ShouldBeFalse(".cache/ is renamed to .scriptcs_cache/");

--- a/test/ScriptCs.Tests.Acceptance/PackageInstallation.cs
+++ b/test/ScriptCs.Tests.Acceptance/PackageInstallation.cs
@@ -14,24 +14,24 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "When I install ScriptCs.Adder"
-                .f(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory = ScenarioDirectory.Create(scenario)));
+                .x(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory = ScenarioDirectory.Create(scenario)));
 
             "Then the ScriptCs.Adder NuGet package is added to the packages folder"
-                .f(() => File.Exists(
+                .x(() => File.Exists(
                         Path.Combine(
                             directory.Map(ScriptCsExe.PackagesFolder),
                             "ScriptCs.Adder.Local.0.1.1/ScriptCs.Adder.Local.0.1.1.nupkg"))
                     .ShouldBeTrue());
 
             "And the ScriptCs.Adder assembly is extracted"
-                .f(() => File.Exists(
+                .x(() => File.Exists(
                         Path.Combine(
                             directory.Map(ScriptCsExe.PackagesFolder),
                             "ScriptCs.Adder.Local.0.1.1/lib/net45/ScriptCs.Adder.dll"))
                     .ShouldBeTrue());
 
             "And ScriptCs.Adder is added to the packages file"
-                .f(() => File.ReadAllText(directory.Map(ScriptCsExe.PackagesFile)).ShouldContain(
+                .x(() => File.ReadAllText(directory.Map(ScriptCsExe.PackagesFile)).ShouldContain(
                     @"<package id=""ScriptCs.Adder.Local"" version=""0.1.1"" targetFramework=""net45"" />"));
         }
     }

--- a/test/ScriptCs.Tests.Acceptance/PackageSaving.cs
+++ b/test/ScriptCs.Tests.Acceptance/PackageSaving.cs
@@ -14,17 +14,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "When I install ScriptCs.Adder manually"
-                .f(() =>
+                .x(() =>
                 {
                     ScriptCsExe.Install("ScriptCs.Adder.Local", directory = ScenarioDirectory.Create(scenario));
                     directory.DeleteFile(ScriptCsExe.PackagesFile);
                 });
 
             "And I save packages"
-                .f(() => ScriptCsExe.Save(directory));
+                .x(() => ScriptCsExe.Save(directory));
 
             "Then ScriptCs.Adder is added to the packages file"
-                .f(() => File.ReadAllText(directory.Map(ScriptCsExe.PackagesFile)).ShouldContain(
+                .x(() => File.ReadAllText(directory.Map(ScriptCsExe.PackagesFile)).ShouldContain(
                     @"<package id=""ScriptCs.Adder.Local"" version=""0.1.1"" targetFramework=""net45"" />"));
         }
     }

--- a/test/ScriptCs.Tests.Acceptance/Packages.cs
+++ b/test/ScriptCs.Tests.Acceptance/Packages.cs
@@ -15,17 +15,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a simple script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine();"));
 
             "When I install a package which contains a framework assembly reference"
-                .f(() => ScriptCsExe.Install("FrameworkAssemblyReferencer", directory));
+                .x(() => ScriptCsExe.Install("FrameworkAssemblyReferencer", directory));
 
             "And I execute the script"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
 
             "Then there should be no errors"
-                .f(() => exception.ShouldBeNull());
+                .x(() => exception.ShouldBeNull());
         }
 
         [Scenario]
@@ -34,20 +34,20 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a simple script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine();"));
 
             "When I install a package"
-                .f(() => ScriptCsExe.Install("Duplicate.A", directory));
+                .x(() => ScriptCsExe.Install("Duplicate.A", directory));
 
             "And I install another package containing the same assembly"
-                .f(() => ScriptCsExe.Install("Duplicate.B", directory));
+                .x(() => ScriptCsExe.Install("Duplicate.B", directory));
 
             "And I execute the script"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", directory)));
 
             "Then there should be no errors"
-                .f(() => exception.ShouldBeNull());
+                .x(() => exception.ShouldBeNull());
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -25,6 +25,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>1701</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -64,15 +65,29 @@
     <Compile Include="Support\MethodBaseExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.TestPlatform.CoreUtilities, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.TestPlatform.CoreUtilities.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.ObjectModel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.TestPlatform.ObjectModel.15.0.0\lib\net46\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll</HintPath>
+    </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Xbehave.Core, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Core.dll</HintPath>
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Runtime" />
+    <Reference Include="System.Runtime.InteropServices.RuntimeInformation, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Runtime.InteropServices.RuntimeInformation.4.0.0\lib\net45\System.Runtime.InteropServices.RuntimeInformation.dll</HintPath>
     </Reference>
-    <Reference Include="Xbehave.Execution.desktop, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.Xml" />
+    <Reference Include="Xbehave.Core, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.2.0.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.2.0-beta0003-build685\lib\net45\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -126,6 +126,7 @@
     <None Include="Support\Gallery\ScriptCs.Logger.ScriptPack.0.1.0.nupkg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Include="xunit.runner.json" />
   </ItemGroup>
   <Import Project="..\..\build\ScriptCs.Common.props" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -68,17 +68,27 @@
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="Xbehave">
-      <HintPath>..\..\packages\Xbehave.1.1.0\lib\net45\Xbehave.dll</HintPath>
+    <Reference Include="Xbehave.Core, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Core.dll</HintPath>
     </Reference>
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="Xbehave.Execution.desktop, Version=2.1.4.0, Culture=neutral, PublicKeyToken=e4957f48888f9fe8, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Xbehave.Core.2.1.4\lib\portable-net45\Xbehave.Execution.desktop.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="packages.config" />
     <None Include="Support\Gallery\Duplicate.A.1.0.0.nupkg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptExecution.cs
@@ -19,14 +19,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a hello world script"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(""Hello world!"");"));
 
             "When I execute the script with debug set to {0}"
-                .f(() => output = ScriptCsExe.Run("foo.csx", debug, directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", debug, directory));
 
             "Then I see 'Hello world!'"
-                .f(() => output.ShouldContain("Hello world!"));
+                .x(() => output.ShouldContain("Hello world!"));
         }
 
         [Scenario]
@@ -37,17 +37,17 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which throws an exception"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"throw new Exception(""BOOM!"");"));
 
             "When I execute the script with debug set to {0}"
-                .f(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", debug, directory)));
+                .x(() => exception = Record.Exception(() => ScriptCsExe.Run("foo.csx", debug, directory)));
 
             "Then scriptcs fails"
-                .f(() => exception.ShouldBeType<ScriptCsException>());
+                .x(() => exception.ShouldBeType<ScriptCsException>());
 
             "And I see the exception message"
-                .f(() => exception.Message.ShouldContain("BOOM!"));
+                .x(() => exception.Message.ShouldContain("BOOM!"));
         }
 
         [Scenario]
@@ -56,14 +56,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which defined a static import"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "using static System.Console;" + Environment.NewLine + @"WriteLine(""Hello world!"");"));
 
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then I see 'Hello world!'"
-                .f(() => output.ShouldContain("Hello world!"));
+                .x(() => output.ShouldContain("Hello world!"));
         }
 
         [Scenario]
@@ -72,14 +72,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which accesses Env"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine(Env)"));
 
             "When I execute the script"
-                .f(()=> output = ScriptCsExe.Run("foo.csx", directory));
+                .x(()=> output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then the Env object is displayed"
-                .f(() => output.ShouldContain("ScriptCs.ScriptEnvironment"));
+                .x(() => output.ShouldContain("ScriptCs.ScriptEnvironment"));
         }
         
         [Scenario]
@@ -88,14 +88,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses dynamic"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"dynamic obj = new ExpandoObject(); obj.foo = ""bar""; Console.WriteLine(obj.foo); ;"));
 
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then the dynamic value is properly returned "
-                .f(() => output.ShouldContain("bar"));
+                .x(() => output.ShouldContain("bar"));
 
         }
 
@@ -105,14 +105,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which accesses Env.ScriptAssembly"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine(Env.ScriptAssembly)"));
 
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then the Assembly is displayed"
-                .f(() => output.ShouldContain("Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
+                .x(() => output.ShouldContain("Version=0.0.0.0, Culture=neutral, PublicKeyToken=null"));
 
         }
 
@@ -122,14 +122,14 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which accesses Env.ScriptPath"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", "Console.WriteLine(Env.ScriptPath)"));
 
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then the ScriptPath is displayed"
-                .f(() => output.ShouldContain("foo.csx"));
+                .x(() => output.ShouldContain("foo.csx"));
         }
 
         [Scenario]
@@ -138,7 +138,7 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which loads another script and accesses Env.LoadedScripts"
-                .f(() =>
+                .x(() =>
                 {
                     directory = ScenarioDirectory.Create(scenario)
                         .WriteLine(
@@ -150,10 +150,10 @@ namespace ScriptCs.Tests.Acceptance
                     
 
             "When I execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then the loaded script path is displayed"
-                .f(() => output.ShouldContain("bar.csx"));
+                .x(() => output.ShouldContain("bar.csx"));
         }
 
 

--- a/test/ScriptCs.Tests.Acceptance/ScriptLibraries.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptLibraries.cs
@@ -16,24 +16,24 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Calculator to print the sum of 40 and 2"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(new Calculator().Add(40, 2));"));
 
             "And ScriptCs.Calculator is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
 
             "When executing the script"
-                .f(() =>
+                .x(() =>
                 {
                     var scriptArgs = new[] { "-loglevel", "info" };
                     output = ScriptCsExe.Run("foo.csx", false, Enumerable.Empty<string>(), scriptArgs, directory);
                 });
 
             "Then I see 42"
-                .f(() => output.ShouldContain("42"));
+                .x(() => output.ShouldContain("42"));
 
             "Then I see INFO outputted from the required Logger script pack"
-                .f(() => output.ShouldContain("INFO"));
+                .x(() => output.ShouldContain("INFO"));
         }
 
         [Scenario(Skip = "Failing with a path length exception")]
@@ -42,17 +42,17 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Calculator"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(""Type:"" + new Calculator().GetType().Name);" + Environment.NewLine + "Environment.Exit(0);"));
 
             "And ScriptCs.Calculator is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
 
             "When executing the script into REPL"
-                .f(() => output = ScriptCsExe.Run("foo.csx", false, new[] { "-r" }, directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", false, new[] { "-r" }, directory));
 
             "Then the ScriptCs.Calculator instance is created"
-                .f(() => output.ShouldContain("Type:Calculator"));
+                .x(() => output.ShouldContain("Type:Calculator"));
         }
 
         [Scenario]
@@ -61,7 +61,7 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Calculator and it is non-rooted"
-                .f(() =>
+                .x(() =>
                 {
                     directory = ScenarioDirectory.Create(scenario);
                     scriptDirectory = ScenarioDirectory.Create(Path.Combine(scenario, "script"))
@@ -69,13 +69,13 @@ namespace ScriptCs.Tests.Acceptance
                 });
 
             "And ScriptCs.Calculator is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Calculator", scriptDirectory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Calculator", scriptDirectory));
 
             "When executing the script"
-                .f(() => output = ScriptCsExe.Run(Path.Combine("script", "foo.csx"), false, directory));
+                .x(() => output = ScriptCsExe.Run(Path.Combine("script", "foo.csx"), false, directory));
 
             "Then the ScriptCs.Calculator instance is created"
-                .f(() => output.ShouldContain("Type:Calculator"));
+                .x(() => output.ShouldContain("Type:Calculator"));
         }
 
 
@@ -85,17 +85,17 @@ namespace ScriptCs.Tests.Acceptance
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Calculator to print the product of 7 and 6"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(new Calculator().Multiply(7, 6));"));
 
             "And ScriptCs.Calculator is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Calculator", directory));
 
             "When executing the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then I see 42"
-                .f(() => output.ShouldContain("42"));
+                .x(() => output.ShouldContain("42"));
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
+++ b/test/ScriptCs.Tests.Acceptance/ScriptPacks.cs
@@ -13,17 +13,17 @@
             var scenario = MethodBase.GetCurrentMethod().GetFullName();
 
             "Given a script which uses ScriptCs.Adder to print the sum of 1234 and 5678"
-                .f(() => directory = ScenarioDirectory.Create(scenario)
+                .x(() => directory = ScenarioDirectory.Create(scenario)
                     .WriteLine("foo.csx", @"Console.WriteLine(Require<Adder>().Add(1234, 5678));"));
 
             "And ScriptCs.Adder is installed"
-                .f(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
+                .x(() => ScriptCsExe.Install("ScriptCs.Adder.Local", directory));
 
             "When execute the script"
-                .f(() => output = ScriptCsExe.Run("foo.csx", directory));
+                .x(() => output = ScriptCsExe.Run("foo.csx", directory));
 
             "Then I see 6912"
-                .f(() => output.ShouldContain("6912"));
+                .x(() => output.ShouldContain("6912"));
         }
     }
 }

--- a/test/ScriptCs.Tests.Acceptance/app.config
+++ b/test/ScriptCs.Tests.Acceptance/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/test/ScriptCs.Tests.Acceptance/app.config
+++ b/test/ScriptCs.Tests.Acceptance/app.config
@@ -10,6 +10,10 @@
         <assemblyIdentity name="xunit.execution.desktop" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.VisualStudio.TestPlatform.ObjectModel" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="11.0.0.0-15.0.0.0" newVersion="15.0.0.0" />
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/ScriptCs.Tests.Acceptance/packages.config
+++ b/test/ScriptCs.Tests.Acceptance/packages.config
@@ -11,4 +11,5 @@
   <package id="xunit.core" version="2.2.0" targetFramework="net461" />
   <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
   <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.runner.console" version="2.2.0" targetFramework="net461" developmentDependency="true" />
 </packages>

--- a/test/ScriptCs.Tests.Acceptance/packages.config
+++ b/test/ScriptCs.Tests.Acceptance/packages.config
@@ -1,8 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.TestPlatform.ObjectModel" version="15.0.0" targetFramework="net461" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
-  <package id="Xbehave" version="2.1.4" targetFramework="net461" />
-  <package id="Xbehave.Core" version="2.1.4" targetFramework="net461" />
+  <package id="System.Runtime.InteropServices.RuntimeInformation" version="4.0.0" targetFramework="net461" />
+  <package id="Xbehave" version="2.2.0-beta0003-build685" targetFramework="net461" />
+  <package id="Xbehave.Core" version="2.2.0-beta0003-build685" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net461" />

--- a/test/ScriptCs.Tests.Acceptance/packages.config
+++ b/test/ScriptCs.Tests.Acceptance/packages.config
@@ -1,7 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Should" version="1.1.20" targetFramework="net45" />
-  <package id="Xbehave" version="1.1.0" targetFramework="net45" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="Xbehave" version="2.1.4" targetFramework="net461" />
+  <package id="Xbehave.Core" version="2.1.4" targetFramework="net461" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
 </packages>

--- a/test/ScriptCs.Tests.Acceptance/xunit.runner.json
+++ b/test/ScriptCs.Tests.Acceptance/xunit.runner.json
@@ -1,0 +1,3 @@
+﻿{
+  "parallelizeTestCollections": false
+}

--- a/test/ScriptCs.Tests/CleanCommandTests.cs
+++ b/test/ScriptCs.Tests/CleanCommandTests.cs
@@ -1,9 +1,9 @@
 ﻿using Moq;
-using Ploeh.AutoFixture.Xunit;
+using Ploeh.AutoFixture.Xunit2;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
-using Xunit.Extensions;
+using Xunit;
 
 namespace ScriptCs.Tests
 {   

--- a/test/ScriptCs.Tests/ConfigTests.cs
+++ b/test/ScriptCs.Tests/ConfigTests.cs
@@ -4,6 +4,7 @@ using Xunit.Extensions;
 namespace ScriptCs.Tests
 {
     using ScriptCs.Contracts;
+    using Xunit;
 
     public class ConfigTests
     {

--- a/test/ScriptCs.Tests/ExecuteLooseScriptCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteLooseScriptCommandTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
 using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Tests/ExecuteReplCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteReplCommandTests.cs
@@ -2,12 +2,11 @@
 using System.Collections.Generic;
 using System.Text;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
-using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
+++ b/test/ScriptCs.Tests/ExecuteScriptCommandTests.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Moq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
 using Should;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Tests/InstallCommandTests.cs
+++ b/test/ScriptCs.Tests/InstallCommandTests.cs
@@ -5,11 +5,11 @@ using System.Runtime.Versioning;
 using Moq;
 using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoMoq;
-using Ploeh.AutoFixture.Xunit;
 using ScriptCs.Command;
 using ScriptCs.Contracts;
 using ScriptCs.Hosting;
-using Xunit.Extensions;
+using Xunit;
+using Ploeh.AutoFixture.Xunit2;
 
 namespace ScriptCs.Tests
 {

--- a/test/ScriptCs.Tests/ScriptCs.Tests.csproj
+++ b/test/ScriptCs.Tests/ScriptCs.Tests.csproj
@@ -64,17 +64,20 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="Moq">
-      <HintPath>..\..\packages\Moq.4.2.1402.2112\lib\net40\Moq.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.1.1.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.1\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture">
-      <HintPath>..\..\packages\AutoFixture.3.18.8\lib\net40\Ploeh.AutoFixture.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.99.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.99\lib\net45\Moq.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.AutoMoq">
-      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.18.8\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.3.50.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
     </Reference>
-    <Reference Include="Ploeh.AutoFixture.Xunit">
-      <HintPath>..\..\packages\AutoFixture.Xunit.3.18.8\lib\net40\Ploeh.AutoFixture.Xunit.dll</HintPath>
+    <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.AutoMoq.3.50.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
+    </Reference>
+    <Reference Include="Ploeh.AutoFixture.Xunit2, Version=3.50.0.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AutoFixture.Xunit2.3.50.3\lib\net45\Ploeh.AutoFixture.Xunit2.dll</HintPath>
     </Reference>
     <Reference Include="Should">
       <HintPath>..\..\packages\Should.1.1.20\lib\Should.dll</HintPath>
@@ -82,11 +85,17 @@
     <Reference Include="System" />
     <Reference Include="System.Runtime" />
     <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="xunit">
-      <HintPath>..\..\packages\xunit.1.9.2\lib\net20\xunit.dll</HintPath>
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
-    <Reference Include="xunit.extensions">
-      <HintPath>..\..\packages\xunit.extensions.1.9.2\lib\net20\xunit.extensions.dll</HintPath>
+    <Reference Include="xunit.assert, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.assert.2.2.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.core, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.core.2.2.0\lib\netstandard1.1\xunit.core.dll</HintPath>
+    </Reference>
+    <Reference Include="xunit.execution.desktop, Version=2.2.0.3545, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\xunit.extensibility.execution.2.2.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Tests/app.config
+++ b/test/ScriptCs.Tests/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1402.2112" newVersion="4.2.1402.2112" />
+        <bindingRedirect oldVersion="0.0.0.0-4.7.99.0" newVersion="4.7.99.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="xunit.extensions" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
@@ -49,6 +49,10 @@
       <dependentAssembly>
         <assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.1" newVersion="4.0.1.1" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="xunit.core" publicKeyToken="8d05b1bb7a6fdb6c" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.2.0.3545" newVersion="2.2.0.3545" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/test/ScriptCs.Tests/packages.config
+++ b/test/ScriptCs.Tests/packages.config
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.AutoMoq" version="3.18.8" targetFramework="net45" />
-  <package id="AutoFixture.Xunit" version="3.18.8" targetFramework="net45" />
-  <package id="Moq" version="4.2.1402.2112" targetFramework="net45" />
+  <package id="AutoFixture" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.AutoMoq" version="3.50.3" targetFramework="net461" />
+  <package id="AutoFixture.Xunit2" version="3.50.3" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.1" targetFramework="net461" />
+  <package id="Moq" version="4.7.99" targetFramework="net461" />
   <package id="Should" version="1.1.20" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.49.0" targetFramework="net45" developmentDependency="true" />
-  <package id="xunit" version="1.9.2" targetFramework="net45" />
-  <package id="xunit.extensions" version="1.9.2" targetFramework="net45" />
+  <package id="xunit" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
+  <package id="xunit.assert" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.core" version="2.2.0" targetFramework="net461" />
+  <package id="xunit.extensibility.execution" version="2.2.0" targetFramework="net461" />
 </packages>

--- a/test/ScriptCsAutoDataAttribute.cs
+++ b/test/ScriptCsAutoDataAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using Ploeh.AutoFixture;
 using Ploeh.AutoFixture.AutoMoq;
-using Ploeh.AutoFixture.Xunit;
-using Xunit.Extensions;
+using Ploeh.AutoFixture.Xunit2;
+using Xunit;
 
 namespace ScriptCs.Tests
 {


### PR DESCRIPTION
Updated to xUnit 2.2.0 + updated all other libraries used in tests.
This also enables scriptcs to work with VS2017 Live Unit Testing feature.

A lot of changes due to namespace changes in the test libraries + binding redirects.