### PR TITLE
Fixed build.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,8 @@ before_install:
       sudo apt-get install msbuild
     fi
 
-install:
-  - mono .nuget/NuGet.exe restore ./.nuget/packages.config -PackagesDirectory ./packages
-  - mono .nuget/NuGet.exe restore ./ScriptCs.sln
-
 script:
-  - mkdir artifacts --parents
-  - msbuild ./ScriptCs.sln /property:Configuration=Release /nologo /verbosity:normal
-  - mono ./packages/xunit.runner.console.2.3.1/tools/net452/xunit.console.exe test/ScriptCs.Tests.Acceptance/bin/Release/net461/ScriptCs.Tests.Acceptance.dll
+  - build.sh
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: csharp
+dotnet: 2.0.0
 sudo: required
 dist: trusty
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,19 +9,10 @@ mono:
 os:
   - linux
 
-# Ensure MSBuild is installed
-before_install:
-  - | 
-    if [ "$TRAVIS_OS_NAME" == "linux" ]
-    then
-      sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
-      echo "deb http://download.mono-project.com/repo/debian wheezy main" | sudo tee /etc/apt/sources.list.d/mono-xamarin.list
-      sudo apt-get -qq update
-      sudo apt-get install msbuild
-    fi
-
 script:
-  - build.sh
+  - ulimit -n8192  
+  - chmod +x build.sh
+  - ./build.sh
 
 addons:
   apt:

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,3 +1,4 @@
 source https://nuget.org/api/v2
 
 nuget FAKE
+nuget xunit.runner.console

--- a/paket.lock
+++ b/paket.lock
@@ -1,3 +1,4 @@
 NUGET
   remote: https://www.nuget.org/api/v2
     FAKE (4.64.6)
+    xunit.runner.console (2.3.1)


### PR DESCRIPTION
I managed to accidentally break `build.sh` in the last PR.
The build script on Travis didn't detect it because it had its own manual steps defined.

Therefore, this PR also updates the travis config to use `build.sh`