### PR TITLE
Update to Roslyn 2.8 (C# 7.3) and to netstandard2.0 (where possible)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -314,3 +314,4 @@ __pycache__/
 # should be stored in the .pubxml.user file.
 
 # End of https://www.gitignore.io/api/visualstudio
+*.DS_Store

--- a/ScriptCs.sln
+++ b/ScriptCs.sln
@@ -15,15 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScriptCs.Core", "src\Script
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScriptCs.Core.Tests", "test\ScriptCs.Core.Tests\ScriptCs.Core.Tests.csproj", "{AC228213-7356-4F0D-BA48-EBA5FB8A7506}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{9659F354-CF48-4FD6-8E0C-E9EB3C2BDA32}"
-	ProjectSection(SolutionItems) = preProject
-		build\Build.proj = build\Build.proj
-		build\ScriptCs.Common.props = build\ScriptCs.Common.props
-		ScriptCs.ruleset = ScriptCs.ruleset
-		build\ScriptCs.Tasks.targets = build\ScriptCs.Tasks.targets
-		build\ScriptCs.Version.props = build\ScriptCs.Version.props
-	EndProjectSection
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScriptCs.Engine.Roslyn.Tests", "test\ScriptCs.Engine.Roslyn.Tests\ScriptCs.Engine.Roslyn.Tests.csproj", "{28D11DE5-9F98-4E0A-8CCC-9CDC19110451}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ScriptCs.Hosting", "src\ScriptCs.Hosting\ScriptCs.Hosting.csproj", "{9AEF2D95-87FB-4829-B384-34BFE076D531}"

--- a/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
+++ b/src/ScriptCs.Contracts/ScriptCs.Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>ScriptCs.Contracts</Title>
     <Authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch</Authors>
     <PackageLicenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</PackageLicenseUrl>
@@ -14,6 +14,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\ScriptCs.Core\Guard.cs" Link="Guard.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Composition" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/src/ScriptCs.Core/ScriptCs.Core.csproj
+++ b/src/ScriptCs.Core/ScriptCs.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>ScriptCs.Core</Title>
     <Authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch</Authors>
     <PackageLicenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
+++ b/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <Version>1.0.0</Version>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <Title>ScriptCs.Engine.Roslyn</Title>
     <Authors>Glenn Block, Filip Wojcieszyn, Justin Rusbatch</Authors>
     <PackageLicenseUrl>https://github.com/scriptcs/scriptcs/blob/master/LICENSE.md</PackageLicenseUrl>

--- a/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
+++ b/src/ScriptCs.Engine.Roslyn/ScriptCs.Engine.Roslyn.csproj
@@ -15,7 +15,7 @@
     <Compile Include="..\ScriptCs.Core\Guard.cs" Link="Guard.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.8.2" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
   </ItemGroup>
   <ItemGroup>

--- a/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
+++ b/src/ScriptCs.Hosting/ScriptCs.Hosting.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="Autofac.Mef" Version="4.0.0" />
     <PackageReference Include="Microsoft.Web.Xdt" Version="2.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NuGet.Core" Version="2.14.0" />
   </ItemGroup>
   <ItemGroup>

--- a/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
+++ b/test/ScriptCs.Engine.Roslyn.Tests/ScriptCs.Engine.Roslyn.Tests.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.1.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Scripting" Version="2.8.2" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />

--- a/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
+++ b/test/ScriptCs.Hosting.Tests/ScriptCs.Hosting.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="AutoFixture.AutoMoq" Version="4.1.0" />
     <PackageReference Include="AutoFixture.Xunit2" Version="4.1.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.6.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="15.7.2" />
     <PackageReference Include="Moq" Version="4.7.99" />
     <PackageReference Include="Should" Version="1.1.20" />
     <PackageReference Include="xunit" Version="2.3.1" />


### PR DESCRIPTION
This PR brings latest Roslyn (2.8.2), with C# 7.3 support.
I also updated the `ScriptCs.Contracts`, `ScriptCs.Core` and `ScriptCs.Engine.Roslyn` to `netstandard2.0` making them much more usable as libraries. 

The entry CLI tool is obviously still `net461`, as well as `ScriptCs.Hosting` (that one has a dependency on old Nuget 2.x, which prevents the upgrade).

My suggestion is to release this in the current format (we are long overdue the 1.0.0 release, the versions on `dev` have long been 1.0.0) and then we can start breaking things and planning what to do next (`scriptcs 2`) - especially around portability and ripping out Nuget 2 and sunsetting `package.config`