### PR TITLE
Fix to flaky test issue & test running on mono

### DIFF
--- a/paket.lock
+++ b/paket.lock
@@ -1,4 +1,4 @@
 NUGET
   remote: https://www.nuget.org/api/v2
-    FAKE (4.64.6)
-    xunit.runner.console (2.3.1)
+    FAKE (4.64.13)
+    xunit.runner.console (2.4.1)

--- a/src/ScriptCs/Program.cs
+++ b/src/ScriptCs/Program.cs
@@ -52,18 +52,19 @@ namespace ScriptCs
 
                 c.OnExecute(() =>
                 {
-                    var configMask = new ConfigMask();
-                    configMask.Repl = false;
-                    configMask.Global = global.HasValue() ? true : (bool?)null;
-                    configMask.Install = package.Value ?? string.Empty; // needed to trigger install of all packages!
-                    configMask.PackageVersion = packageVersion.Value();
-                    configMask.AllowPreRelease = allowPrerelease.HasValue() ? true : (bool?)null;
-                    configMask.Save = save.HasValue() ? true : (bool?)null;
-                    configMask.Global = global.HasValue() ? true : (bool?)null;
-                    configMask.Clean = clean.HasValue() ? true : (bool?)null;
-                    configMask.Output = output.Value();
-                    configMask.Debug = debug.HasValue() ? true : (bool?)null;
-                    configMask.LogLevel = logLevel.ParsedValue;
+                    var configMask = new ConfigMask
+                    {
+                        Repl = false,
+                        Global = global.HasValue() ? true : (bool?)null,
+                        Install = package.Value ?? string.Empty, // needed to trigger install of all packages!
+                        PackageVersion = packageVersion.Value(),
+                        AllowPreRelease = allowPrerelease.HasValue() ? true : (bool?)null,
+                        Save = save.HasValue() ? true : (bool?)null,
+                        Clean = clean.HasValue() ? true : (bool?)null,
+                        Output = output.Value(),
+                        Debug = debug.HasValue() ? true : (bool?)null,
+                        LogLevel = logLevel.ParsedValue
+                    };
 
                     return Application.Run(Config.Create(configFile.Value(), configMask), scriptArgs);
                 });
@@ -83,16 +84,18 @@ namespace ScriptCs
                     return 0;
                 }
 
-                var configMask = new ConfigMask();
-                configMask.Repl = repl.HasValue() ? true : (bool?)null;
-                configMask.ScriptName = scriptNameFallback.HasValue() ? scriptNameFallback.Value() : script.Value;
-                configMask.Debug = debug.HasValue() ? true : (bool?)null;
-                configMask.Eval = eval.Value();
-                configMask.Cache = cache.HasValue() ? true : (bool?)null;
-                configMask.Watch = watch.HasValue() ? true : (bool?)null;
-                configMask.LogLevel = logLevel.ParsedValue;
-                configMask.Modules = modules.Value();
-                configMask.Output = output.Value();
+                var configMask = new ConfigMask
+                {
+                    Repl = repl.HasValue() ? true : (bool?)null,
+                    ScriptName = scriptNameFallback.HasValue() ? scriptNameFallback.Value() : script.Value,
+                    Debug = debug.HasValue() ? true : (bool?)null,
+                    Eval = eval.Value(),
+                    Cache = cache.HasValue() ? true : (bool?)null,
+                    Watch = watch.HasValue() ? true : (bool?)null,
+                    LogLevel = logLevel.ParsedValue,
+                    Modules = modules.Value(),
+                    Output = output.Value()
+                };
 
                 return Application.Run(Config.Create(configFile.Value(), configMask), scriptArgs);
             });
@@ -101,7 +104,7 @@ namespace ScriptCs
             {
                 return app.Execute(nonScriptArgs);
             }
-            catch (CommandParsingException e)
+            catch (CommandParsingException)
             {
                 app.ShowHelp();
                 return 1;

--- a/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
+++ b/test/ScriptCs.Tests.Acceptance/ScriptCs.Tests.Acceptance.csproj
@@ -36,5 +36,8 @@
     <None Update="Support\Gallery\ScriptCs.Logger.ScriptPack.0.1.0.nupkg">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="xunit.runner.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Disable the unit testing running in parallel on the Acceptance tests. #1277 
Verified that all tests runs under mono on Linux and MacOS. #756. [Travis CI Build](https://travis-ci.org/BlackFrog1/scriptcs/builds/456524883)