### PR TITLE
Register the _replType if specified, otherwise use the default Repl

### DIFF
--- a/src/ScriptCs.Hosting/RuntimeServices.cs
+++ b/src/ScriptCs.Hosting/RuntimeServices.cs
@@ -55,9 +55,8 @@ namespace ScriptCs.Hosting
             builder.RegisterInstance(this.LogProvider).Exported(x => x.As<ILogProvider>());
             builder.RegisterType(_scriptEngineType).As<IScriptEngine>().SingleInstance();
             builder.RegisterType(_scriptExecutorType).As<IScriptExecutor>().SingleInstance();
-            builder.RegisterType(_replType).As<IRepl>().SingleInstance();
+            builder.RegisterType(_replType ?? typeof(Repl)).As<IRepl>().SingleInstance();
             builder.RegisterType<ScriptServices>().SingleInstance();
-            builder.RegisterType<Repl>().As<IRepl>().SingleInstance();
             builder.RegisterType<Printers>().SingleInstance();
 
             RegisterLineProcessors(builder);

--- a/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
+++ b/test/ScriptCs.Hosting.Tests/RuntimeServicesTests.cs
@@ -272,6 +272,14 @@ namespace ScriptCs.Hosting.Tests
             }
 
             [Fact]
+            public void ShouldRegisterTheOverriddenRepl()
+            {
+                var mock = new Mock<IRepl>();
+                _overrides[ typeof( IRepl ) ] = mock.Object.GetType();
+                _runtimeServices.Container.Resolve<IRepl>().ShouldBeType( mock.Object.GetType() );
+            }
+
+            [Fact]
             public void ShouldLogOnDebugAnAssemblyLoadFailure()
             {
                 // arrange


### PR DESCRIPTION
Fixes issue #1298 