### PR TITLE
Write content to disk as UTF8 in FileSystem

### DIFF
--- a/src/ScriptCs.Core/FileSystem.cs
+++ b/src/ScriptCs.Core/FileSystem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using ScriptCs.Contracts;
 
 namespace ScriptCs
@@ -129,7 +130,7 @@ namespace ScriptCs
 
         public virtual void WriteToFile(string path, string text)
         {
-            File.WriteAllText(path, text);
+            File.WriteAllText(path, text,Encoding.UTF8);
         }
 
         public virtual Stream CreateFileStream(string filePath, FileMode mode)


### PR DESCRIPTION

## Why?
The reason why I made this PR is because the launcher file created by :openvs command would result VS not able to find the script file if the file name or path is not in English. 

After I dig into the launcher file, the content like below. The file path is the problem.
```xml
Microsoft Visual Studio Solution File, Format Version 12.00
# Visual Studio Version 16
VisualStudioVersion = 16.0.31409.214
MinimumVisualStudioVersion = 10.0.40219.1
Project("{911E67C6-3D85-4FCE-B560-20A9C3E3FF48}") = "scriptcs", "C:\tools\scriptcs\Release\scriptcs.exe", "{9F27174A-6008-4476-B5BE-BD6DCE9A0454}"
	ProjectSection(DebuggerProjectSystem) = preProject
		PortSupplier = 00000000-0000-0000-0000-000000000000
		Executable = C:\tools\scriptcs\Release\scriptcs.exe
		RemoteMachine = localhost
		StartingDirectory = C:\workspace\github\code_review\Linked List\**206. åè½¬é“¾è¡**¨
		Arguments = solution.csx -debug -loglevel info
		Environment = Default
		LaunchingEngine = 00000000-0000-0000-0000-000000000000
		UseLegacyDebugEngines = No
		LaunchSQLEngine = No
		AttachLaunchAction = No
		IORedirection = Auto
	EndProjectSection
EndProject
Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{CDD5E630-9123-4BD1-A17C-B35480078326}"
	ProjectSection(SolutionItems) = preProject
		..\..\..\..\..\workspace\github\code_review\Linked List\206. ·´×ªÁ´±í\solution.csx = ..\..\..\..\..\workspace\github\code_review\Linked List\206. ·´×ªÁ´±í\solution.csx
	EndProjectSection
EndProject
```

Then I find FileSystem.WriteToFile() causing this.

## How?

After specifying the encoding to UTF8 in File.WriteAllText() method, then the created content of launcher file is good. And VS  loads the script file as expected.

```c#
        public virtual void WriteToFile(string path, string text)
        {
            File.WriteAllText(path, text,Encoding.UTF8);
        }
```

