### PR TITLE
Update chocolateyInstall.ps1

### DIFF
--- a/src/ScriptCs/Properties/chocolateyInstall.ps1
+++ b/src/ScriptCs/Properties/chocolateyInstall.ps1
@@ -1,4 +1,4 @@
-﻿try {
+try {
     $tools = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
 
     if (Test-Path "$tools\..\lib") {
@@ -36,8 +36,8 @@
     Update-SessionEnvironment
     # End upgrade handling.
 
-    Write-ChocolateySuccess 'scriptcs'
+    Write-Host "Success!"
 } catch {
-    Write-ChocolateyFailure 'scriptcs' "$($_.Exception.Message)"
+    Write-Warning "$($_.Exception.Message)"
     throw
 }


### PR DESCRIPTION
Replaced `Write-ChocolateySuccess` and `Write-ChocolateySuccess` with `Write-Host` and `Write-Warning` to allow to script to work again.